### PR TITLE
Feature/allow custom networking implementations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,7 @@ export {
   OAuth2ClientCredentials
 } from './lib/oauth2/models/OAuth2ClientCredentials';
 export { AccessTokenProvider } from './lib/oauth2/models/AccessTokenProvider';
-export {
-  HalClient,
-  DefaultHalClient
-} from './lib/hal/services/HalClient';
+export { HalClient, DefaultHalClient } from './lib/hal/services/HalClient';
 export {
   HalResource,
   HalResourceConstructor

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { DynamicContent, DynamicContentClient } from './lib/DynamicContent';
+export { DynamicContent } from './lib/DynamicContent';
 export { OAuth2Client } from './lib/oauth2/services/OAuth2Client';
 export {
   OAuth2ClientCredentials
@@ -6,14 +6,17 @@ export {
 export { AccessTokenProvider } from './lib/oauth2/models/AccessTokenProvider';
 export {
   HalClient,
-  DefaultHalClient,
-  AxiosHalClient,
-  ResourceRequest
+  DefaultHalClient
 } from './lib/hal/services/HalClient';
 export {
   HalResource,
   HalResourceConstructor
 } from './lib/hal/models/HalResource';
+
+export { HttpClient } from './lib/http/HttpClient';
+export { HttpRequest, HttpMethod } from './lib/http/HttpRequest';
+export { HttpResponse } from './lib/http/HttpResponse';
+export { AxiosHttpClient } from './lib/http/AxiosHttpClient';
 
 export { Event } from './lib/model/Event';
 export { Edition } from './lib/model/Edition';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { DynamicContent } from './lib/DynamicContent';
+export { DynamicContent, DynamicContentClient } from './lib/DynamicContent';
 export { OAuth2Client } from './lib/oauth2/services/OAuth2Client';
 export {
   OAuth2ClientCredentials

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { OAuth2Client } from './lib/oauth2/services/OAuth2Client';
 export {
   OAuth2ClientCredentials
 } from './lib/oauth2/models/OAuth2ClientCredentials';
+export { AccessToken } from './lib/oauth2/models/AccessToken';
 export { AccessTokenProvider } from './lib/oauth2/models/AccessTokenProvider';
 export { HalClient, DefaultHalClient } from './lib/hal/services/HalClient';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,17 @@ export { OAuth2Client } from './lib/oauth2/services/OAuth2Client';
 export {
   OAuth2ClientCredentials
 } from './lib/oauth2/models/OAuth2ClientCredentials';
+export { AccessTokenProvider } from './lib/oauth2/models/AccessTokenProvider';
+export {
+  HalClient,
+  DefaultHalClient,
+  AxiosHalClient,
+  ResourceRequest
+} from './lib/hal/services/HalClient';
+export {
+  HalResource,
+  HalResourceConstructor
+} from './lib/hal/models/HalResource';
 
 export { Event } from './lib/model/Event';
 export { Edition } from './lib/model/Edition';

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1,7 +1,9 @@
 import { AxiosRequestConfig } from 'axios';
 import { DynamicContent, DynamicContentConfig } from './DynamicContent';
-import { AxiosHalClient, HalClient } from './hal/services/HalClient';
+import { HalClient } from './hal/services/HalClient';
 import { HalMocks } from './hal/utils/HalMock';
+import { AxiosHttpClient } from './http/AxiosHttpClient';
+import { HttpClient } from './http/HttpClient';
 import { AccessTokenProvider } from './oauth2/models/AccessTokenProvider';
 import { OAuth2ClientCredentials } from './oauth2/models/OAuth2ClientCredentials';
 
@@ -717,7 +719,9 @@ export class DynamicContentFixtures {
     const mocks = new HalMocks(mock);
 
     // Hubs
-    mocks.collection('/hubs', 'hubs', [HUB]);
+    mocks.collection('https://api.amplience.net/v2/content/hubs', 'hubs', [
+      HUB
+    ]);
     mocks
       .resource(HUB)
       .nestedCollection('content-repositories', {}, 'content-repositories', [
@@ -799,7 +803,7 @@ export class MockDynamicContent extends DynamicContent {
   constructor(
     clientCredentials?: OAuth2ClientCredentials,
     dcConfig?: DynamicContentConfig,
-    config?: AxiosRequestConfig
+    httpClient?: AxiosRequestConfig
   ) {
     super(
       clientCredentials || {
@@ -807,14 +811,14 @@ export class MockDynamicContent extends DynamicContent {
         client_secret: 'client_secret'
       },
       dcConfig,
-      config
+      httpClient
     );
   }
 
   protected createTokenClient(
     dcConfig: DynamicContentConfig,
-    clientConfig: AxiosRequestConfig,
-    clientCredentials: OAuth2ClientCredentials
+    clientCredentials: OAuth2ClientCredentials,
+    httpClient: HttpClient
   ): AccessTokenProvider {
     return {
       getToken: () =>
@@ -828,15 +832,15 @@ export class MockDynamicContent extends DynamicContent {
 
   protected createResourceClient(
     dcConfig: DynamicContentConfig,
-    clientConfig: AxiosRequestConfig,
-    tokenProvider: AccessTokenProvider
+    tokenProvider: AccessTokenProvider,
+    httpClient: HttpClient
   ): HalClient {
     const client = super.createResourceClient(
       dcConfig,
-      clientConfig,
-      tokenProvider
+      tokenProvider,
+      httpClient
     );
-    this.mock = new MockAdapter((client as AxiosHalClient).client);
+    this.mock = new MockAdapter((httpClient as AxiosHttpClient).client);
     DynamicContentFixtures.install(this.mock);
     return client;
   }

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -629,6 +629,9 @@ export const LOCALIZATION_JOB = {
   }
 };
 
+/**
+ * @hidden
+ */
 export const FOLDER = {
   id: '5b72ed68d6018001c81ef05b',
   name: 'A folder to end all folders',

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1,10 +1,9 @@
 import { AxiosRequestConfig } from 'axios';
 import { DynamicContent, DynamicContentConfig } from './DynamicContent';
-import { HalClient } from './hal/services/HalClient';
+import { AxiosHalClient, HalClient } from './hal/services/HalClient';
 import { HalMocks } from './hal/utils/HalMock';
 import { AccessTokenProvider } from './oauth2/models/AccessTokenProvider';
 import { OAuth2ClientCredentials } from './oauth2/models/OAuth2ClientCredentials';
-import { OAuth2Client } from './oauth2/services/OAuth2Client';
 
 /* tslint:disable:object-literal-sort-keys */
 
@@ -607,7 +606,7 @@ export class MockDynamicContent extends DynamicContent {
       clientConfig,
       tokenProvider
     );
-    this.mock = new MockAdapter(client.client);
+    this.mock = new MockAdapter((client as AxiosHalClient).client);
     DynamicContentFixtures.install(this.mock);
     return client;
   }

--- a/src/lib/DynamicContent.ts
+++ b/src/lib/DynamicContent.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { HalClient } from './hal/services/HalClient';
+import { AxiosHalClient, HalClient } from './hal/services/HalClient';
 import { ContentItem } from './model/ContentItem';
 import { ContentRepository } from './model/ContentRepository';
 import { Edition } from './model/Edition';
@@ -224,9 +224,6 @@ export class DynamicContent extends DynamicContentClient<AxiosRequestConfig> {
   ): HalClient {
     const config = { ...clientConfig };
     config.baseURL = dcConfig.apiUrl;
-    return new HalClient(
-      () => tokenProvider.getToken().then(y => y.access_token),
-      config
-    );
+    return new AxiosHalClient(tokenProvider, config);
   }
 }

--- a/src/lib/DynamicContent.ts
+++ b/src/lib/DynamicContent.ts
@@ -67,7 +67,7 @@ export interface DynamicContentConfig {
  * await repository.related.contentItems.create(contentItem);
  * ```
  */
-export abstract class DynamicContent {
+export class DynamicContent {
   /**
    * Hub Resources
    */

--- a/src/lib/hal/models/HalResource.spec.ts
+++ b/src/lib/hal/models/HalResource.spec.ts
@@ -9,6 +9,9 @@ import { HalResource } from './HalResource';
 // tslint:disable-next-line
 const MockAdapter = require('axios-mock-adapter');
 
+/**
+ * @hidden
+ */
 const tokenProvider = {
   getToken: () =>
     Promise.resolve({

--- a/src/lib/hal/models/HalResource.spec.ts
+++ b/src/lib/hal/models/HalResource.spec.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { HalClient } from '../services/HalClient';
+import { AxiosHalClient, HalClient } from '../services/HalClient';
 import { HalResource } from './HalResource';
 
 // axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
@@ -8,6 +8,15 @@ import { HalResource } from './HalResource';
  */
 // tslint:disable-next-line
 const MockAdapter = require('axios-mock-adapter');
+
+const tokenProvider = {
+  getToken: () =>
+    Promise.resolve({
+      access_token: 'token',
+      expires_in: 500,
+      refresh_token: 'refresh'
+    })
+};
 
 /**
  * @hidden
@@ -27,7 +36,7 @@ class MockResource extends HalResource {
 }
 
 test('embedded resources should be lazy parsed', t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
   const resource = client.parse(
     {
       _embedded: {
@@ -56,7 +65,7 @@ test('input JSON should be parsed', async t => {
 });
 
 test('fetchLinkedResource should follow the resource link', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
   const mock = new MockAdapter(client.client);
 
   const resource = client.parse(
@@ -79,7 +88,7 @@ test('fetchLinkedResource should follow the resource link', async t => {
 });
 
 test('fetchLinkedResource should return null if link is missing', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
 
   const resource = client.parse(
     {
@@ -93,7 +102,7 @@ test('fetchLinkedResource should return null if link is missing', async t => {
 });
 
 test('fetchLinkedResource should reject if no client is linked', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
   const resource = new MockResource({
     _links: {}
   });
@@ -102,7 +111,7 @@ test('fetchLinkedResource should reject if no client is linked', async t => {
 });
 
 test('createLinkedResource should follow the resource link', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
   const mock = new MockAdapter(client.client);
 
   const resource = client.parse(
@@ -125,7 +134,7 @@ test('createLinkedResource should follow the resource link', async t => {
 });
 
 test('createLinkedResource should return null if link is missing', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
 
   const resource = client.parse(
     {
@@ -139,7 +148,7 @@ test('createLinkedResource should return null if link is missing', async t => {
 });
 
 test('createLinkedResource should reject if no client is linked', async t => {
-  const client = new HalClient(() => Promise.resolve('token'), {});
+  const client = new AxiosHalClient(tokenProvider, {});
   const resource = new MockResource({
     _links: {}
   });

--- a/src/lib/hal/models/HalResource.spec.ts
+++ b/src/lib/hal/models/HalResource.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { AxiosHalClient, HalClient } from '../services/HalClient';
+import { AxiosHttpClient } from '../../http/AxiosHttpClient';
+import { DefaultHalClient, HalClient } from '../services/HalClient';
 import { HalResource } from './HalResource';
 
 // axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
@@ -24,6 +25,17 @@ const tokenProvider = {
 /**
  * @hidden
  */
+function createMockClient(): [HalClient, any] {
+  const httpClient = new AxiosHttpClient({});
+  const client = new DefaultHalClient('', httpClient, tokenProvider);
+  const mock = new MockAdapter(httpClient.client);
+
+  return [client, mock];
+}
+
+/**
+ * @hidden
+ */
 class MockResource extends HalResource {
   public name?: string;
 
@@ -39,7 +51,8 @@ class MockResource extends HalResource {
 }
 
 test('embedded resources should be lazy parsed', t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
+
   const resource = client.parse(
     {
       _embedded: {
@@ -68,8 +81,7 @@ test('input JSON should be parsed', async t => {
 });
 
 test('fetchLinkedResource should follow the resource link', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   const resource = client.parse(
     {
@@ -91,7 +103,7 @@ test('fetchLinkedResource should follow the resource link', async t => {
 });
 
 test('fetchLinkedResource should return null if link is missing', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
 
   const resource = client.parse(
     {
@@ -105,7 +117,7 @@ test('fetchLinkedResource should return null if link is missing', async t => {
 });
 
 test('fetchLinkedResource should reject if no client is linked', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
   const resource = new MockResource({
     _links: {}
   });
@@ -114,8 +126,7 @@ test('fetchLinkedResource should reject if no client is linked', async t => {
 });
 
 test('createLinkedResource should follow the resource link', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   const resource = client.parse(
     {
@@ -137,7 +148,7 @@ test('createLinkedResource should follow the resource link', async t => {
 });
 
 test('createLinkedResource should return null if link is missing', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
 
   const resource = client.parse(
     {
@@ -151,7 +162,7 @@ test('createLinkedResource should return null if link is missing', async t => {
 });
 
 test('createLinkedResource should reject if no client is linked', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
   const resource = new MockResource({
     _links: {}
   });

--- a/src/lib/hal/services/CURIEs.ts
+++ b/src/lib/hal/services/CURIEs.ts
@@ -1,3 +1,6 @@
+/**
+ * @hidden
+ */
 // tslint:disable-next-line
 const template = require('url-template');
 

--- a/src/lib/hal/services/HalClient.spec.ts
+++ b/src/lib/hal/services/HalClient.spec.ts
@@ -10,6 +10,9 @@ import { AxiosHalClient, HalClient } from './HalClient';
 // tslint:disable-next-line
 const MockAdapter = require('axios-mock-adapter');
 
+/**
+ * @hidden
+ */
 const tokenProvider = {
   getToken: () =>
     Promise.resolve({

--- a/src/lib/hal/services/HalClient.spec.ts
+++ b/src/lib/hal/services/HalClient.spec.ts
@@ -1,7 +1,8 @@
 import test from 'ava';
+import { AxiosHttpClient } from '../../http/AxiosHttpClient';
 import { ContentRepository } from '../../model/ContentRepository';
 import { Hub } from '../../model/Hub';
-import { AxiosHalClient, HalClient } from './HalClient';
+import { DefaultHalClient, HalClient } from './HalClient';
 
 // axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
@@ -9,6 +10,17 @@ import { AxiosHalClient, HalClient } from './HalClient';
  */
 // tslint:disable-next-line
 const MockAdapter = require('axios-mock-adapter');
+
+/**
+ * @hidden
+ */
+function createMockClient(): [HalClient, any] {
+  const httpClient = new AxiosHttpClient({});
+  const client = new DefaultHalClient('', httpClient, tokenProvider);
+  const mock = new MockAdapter(httpClient.client);
+
+  return [client, mock];
+}
 
 /**
  * @hidden
@@ -23,8 +35,7 @@ const tokenProvider = {
 };
 
 test('fetchResource should load and parse resource', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onGet('/hubs/1').reply(200, {
     name: 'hub 1'
@@ -35,8 +46,7 @@ test('fetchResource should load and parse resource', async t => {
 });
 
 test('fetchLinkedResource should follow href', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onGet('/hubs/1').reply(200, {
     name: 'hub 1'
@@ -47,8 +57,7 @@ test('fetchLinkedResource should follow href', async t => {
 });
 
 test('fetchLinkedResource should process templated links', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onGet('/hubs/1').reply(200, {
     name: 'hub 1'
@@ -63,8 +72,7 @@ test('fetchLinkedResource should process templated links', async t => {
 });
 
 test('createResource should post and parse the resource', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onPost('/hubs').reply(200, {
     id: 'hub 1',
@@ -78,8 +86,7 @@ test('createResource should post and parse the resource', async t => {
 });
 
 test('createLinkedResource should follow href', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onPost('/hubs').reply(200, {
     id: 'hub 1',
@@ -93,8 +100,7 @@ test('createLinkedResource should follow href', async t => {
 });
 
 test('createLinkedResource should process templated links', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock.onPost('/hubs/1/content-repositories').reply(200, {
     id: 'repo 1',
@@ -113,8 +119,7 @@ test('createLinkedResource should process templated links', async t => {
 });
 
 test('requests should include auth token', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock
     .onGet('/hubs/1', undefined, {
@@ -130,20 +135,19 @@ test('requests should include auth token', async t => {
 });
 
 test('should ask for token from provider every request', async t => {
-  let tokenCount = 0;
-  const client = new AxiosHalClient(
-    {
-      getToken: () =>
-        Promise.resolve({
-          access_token: 'token' + tokenCount++,
-          expires_in: 500,
-          refresh_token: 'refresh'
-        })
-    },
-    {}
-  );
+  const httpClient = new AxiosHttpClient({});
 
-  const mock = new MockAdapter(client.client);
+  let tokenCount = 0;
+  const client = new DefaultHalClient('', httpClient, {
+    getToken: () =>
+      Promise.resolve({
+        access_token: 'token' + tokenCount++,
+        expires_in: 500,
+        refresh_token: 'refresh'
+      })
+  });
+
+  const mock = new MockAdapter(httpClient.client);
   mock
     .onGet('/hubs/1', undefined, {
       Accept: 'application/json, text/plain, */*',
@@ -167,13 +171,15 @@ test('should ask for token from provider every request', async t => {
 });
 
 test('parse should instantiate and parse the resource', t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
+
   const hub = client.parse({ name: 'hub' }, Hub);
   t.is(hub.name, 'hub');
 });
 
 test('serialize should make a copy of the object', t => {
-  const client = new AxiosHalClient(tokenProvider, {});
+  const [client, mock] = createMockClient();
+
   const hub = new Hub();
   hub.name = 'hub';
   const hubJson = client.serialize(hub);
@@ -183,8 +189,7 @@ test('serialize should make a copy of the object', t => {
 });
 
 test('api errors should be surfaced in the rejection error', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock
     .onGet('/hubs/1', undefined, {
@@ -202,8 +207,7 @@ test('api errors should be surfaced in the rejection error', async t => {
 });
 
 test('unknown errors should describe the status code', async t => {
-  const client = new AxiosHalClient(tokenProvider, {});
-  const mock = new MockAdapter(client.client);
+  const [client, mock] = createMockClient();
 
   mock
     .onGet('/hubs/1', undefined, {

--- a/src/lib/hal/services/HalClient.ts
+++ b/src/lib/hal/services/HalClient.ts
@@ -26,6 +26,13 @@ export interface HalClient {
     resourceConstructor: HalResourceConstructor<T>
   ): Promise<T>;
 
+  performActionThatReturnsResource<T extends HalResource>(
+    link: HalLink,
+    params: any,
+    data: any,
+    resourceConstructor: HalResourceConstructor<T>
+  ): Promise<T>;
+
   createResource<T extends HalResource>(
     path: string,
     resource: T,

--- a/src/lib/http/AxiosHttpClient.spec.ts
+++ b/src/lib/http/AxiosHttpClient.spec.ts
@@ -1,0 +1,110 @@
+import test from 'ava';
+import { AxiosHttpClient } from './AxiosHttpClient';
+import { HttpMethod } from './HttpRequest';
+
+// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
+/**
+ * @hidden
+ */
+// tslint:disable-next-line
+const MockAdapter = require('axios-mock-adapter');
+
+test('client should use provided base url', async t => {
+  const client = new AxiosHttpClient({
+    baseURL: 'http://mywebsite.com'
+  });
+
+  const mock = new MockAdapter(client.client);
+  mock.onGet('http://mywebsite.com/ping').reply(200, 'pong');
+
+  const response = await client.request({
+    method: HttpMethod.GET,
+    url: 'http://mywebsite.com/ping'
+  });
+
+  t.is(response.data, 'pong');
+});
+
+test('client should return status code', async t => {
+  const client = new AxiosHttpClient({});
+
+  const mock = new MockAdapter(client.client);
+  mock.onGet('/ping').reply(404);
+
+  const response = await client.request({
+    method: HttpMethod.GET,
+    url: '/ping'
+  });
+
+  t.is(response.status, 404);
+});
+
+test('client should use provided method', async t => {
+  const client = new AxiosHttpClient({});
+
+  const mock = new MockAdapter(client.client);
+  mock.onDelete('/resource').reply(200);
+
+  const response = await client.request({
+    method: HttpMethod.DELETE,
+    url: '/resource'
+  });
+
+  t.is(response.status, 200);
+});
+
+test('client should send form data', async t => {
+  const client = new AxiosHttpClient({});
+
+  const mock = new MockAdapter(client.client);
+  mock
+    .onPost(
+      '/oauth/token',
+      'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
+    )
+    .reply(200, {
+      access_token: 'token',
+      expires_in: 0,
+      refresh_token: 'refresh'
+    });
+
+  const response = await client.request({
+    data:
+      'grant_type=client_credentials&client_id=client_id&client_secret=client_secret',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    method: HttpMethod.POST,
+    url: '/oauth/token'
+  });
+
+  t.is(response.status, 200);
+});
+
+test('client should send JSON data', async t => {
+  const client = new AxiosHttpClient({});
+
+  const mock = new MockAdapter(client.client);
+  mock
+    .onPost('/resource/create', {
+      key: 'value'
+    })
+    .reply(200, {
+      access_token: 'token',
+      expires_in: 0,
+      refresh_token: 'refresh'
+    });
+
+  const response = await client.request({
+    data: {
+      key: 'value'
+    },
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    method: HttpMethod.POST,
+    url: '/resource/create'
+  });
+
+  t.is(response.status, 200);
+});

--- a/src/lib/http/AxiosHttpClient.ts
+++ b/src/lib/http/AxiosHttpClient.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+import { HttpClient } from './HttpClient';
+import { HttpRequest } from './HttpRequest';
+import { HttpResponse } from './HttpResponse';
+
+/**
+ * @hidden
+ */
+export class AxiosHttpClient implements HttpClient {
+  public client: AxiosInstance;
+
+  constructor(private config: AxiosRequestConfig) {
+    this.client = axios.create(config);
+  }
+
+  public request(config: HttpRequest): Promise<HttpResponse> {
+    return this.client
+      .request({
+        data: config.data,
+        headers: config.headers,
+        method: config.method,
+        url: config.url
+      })
+      .then(response => {
+        return {
+          data: response.data,
+          status: response.status
+        };
+      })
+      .catch(error => {
+        if (error && error.response) {
+          return {
+            data: error.response.data,
+            status: error.response.status
+          };
+        }
+        return error;
+      });
+  }
+}

--- a/src/lib/http/HttpClient.ts
+++ b/src/lib/http/HttpClient.ts
@@ -1,0 +1,9 @@
+import { HttpRequest } from './HttpRequest';
+import { HttpResponse } from './HttpResponse';
+
+/**
+ * @hidden
+ */
+export interface HttpClient {
+  request(config: HttpRequest): Promise<HttpResponse>;
+}

--- a/src/lib/http/HttpRequest.ts
+++ b/src/lib/http/HttpRequest.ts
@@ -1,0 +1,20 @@
+/**
+ * @hidden
+ */
+export enum HttpMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+  DELETE = 'DELETE'
+}
+
+/**
+ * @hidden
+ */
+export interface HttpRequest {
+  url: string;
+  method: HttpMethod;
+  data?: string | object;
+  headers?: { [key: string]: string };
+}

--- a/src/lib/http/HttpResponse.ts
+++ b/src/lib/http/HttpResponse.ts
@@ -1,0 +1,7 @@
+/**
+ * @hidden
+ */
+export interface HttpResponse {
+  status: number;
+  data: string | object;
+}

--- a/src/lib/oauth2/models/AccessTokenProvider.ts
+++ b/src/lib/oauth2/models/AccessTokenProvider.ts
@@ -1,0 +1,5 @@
+import { AccessToken } from './AccessToken';
+
+export interface AccessTokenProvider {
+  getToken(): Promise<AccessToken>;
+}

--- a/src/lib/oauth2/services/OAuth2Client.spec.ts
+++ b/src/lib/oauth2/services/OAuth2Client.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { AxiosHttpClient } from '../../http/AxiosHttpClient';
 import { OAuth2Client } from './OAuth2Client';
 
 // axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
@@ -9,15 +10,17 @@ import { OAuth2Client } from './OAuth2Client';
 const MockAdapter = require('axios-mock-adapter');
 
 test('get token should request a token on the first invocation', async t => {
+  const httpClient = new AxiosHttpClient({});
   const client = new OAuth2Client(
     {
       client_id: 'client_id',
       client_secret: 'client_secret'
     },
-    {}
+    {},
+    httpClient
   );
 
-  const mock = new MockAdapter(client.client);
+  const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
       'https://auth.adis.ws/oauth/token',
@@ -33,15 +36,17 @@ test('get token should request a token on the first invocation', async t => {
 });
 
 test('get token should cache tokens', async t => {
+  const httpClient = new AxiosHttpClient({});
   const client = new OAuth2Client(
     {
       client_id: 'client_id',
       client_secret: 'client_secret'
     },
-    {}
+    {},
+    httpClient
   );
 
-  const mock = new MockAdapter(client.client);
+  const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
       'https://auth.adis.ws/oauth/token',
@@ -73,15 +78,17 @@ test('get token should cache tokens', async t => {
 });
 
 test('cached tokens should expire', async t => {
+  const httpClient = new AxiosHttpClient({});
   const client = new OAuth2Client(
     {
       client_id: 'client_id',
       client_secret: 'client_secret'
     },
-    {}
+    {},
+    httpClient
   );
 
-  const mock = new MockAdapter(client.client);
+  const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
       'https://auth.adis.ws/oauth/token',
@@ -113,15 +120,17 @@ test('cached tokens should expire', async t => {
 });
 
 test('only one token refresh should be in flight at once', async t => {
+  const httpClient = new AxiosHttpClient({});
   const client = new OAuth2Client(
     {
       client_id: 'client_id',
       client_secret: 'client_secret'
     },
-    {}
+    {},
+    httpClient
   );
 
-  const mock = new MockAdapter(client.client, { delayResponse: 2000 });
+  const mock = new MockAdapter(httpClient.client, { delayResponse: 2000 });
 
   mock
     .onPost(

--- a/src/lib/oauth2/services/OAuth2Client.ts
+++ b/src/lib/oauth2/services/OAuth2Client.ts
@@ -1,11 +1,12 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { AccessToken } from '../models/AccessToken';
+import { AccessTokenProvider } from '../models/AccessTokenProvider';
 import { OAuth2ClientCredentials } from '../models/OAuth2ClientCredentials';
 
 /**
  * @hidden
  */
-export class OAuth2Client {
+export class OAuth2Client implements AccessTokenProvider {
   public client: AxiosInstance;
 
   private clientCredentials: OAuth2ClientCredentials;

--- a/src/lib/oauth2/services/OAuth2Client.ts
+++ b/src/lib/oauth2/services/OAuth2Client.ts
@@ -1,4 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { HttpClient } from '../../http/HttpClient';
+import { HttpMethod } from '../../http/HttpRequest';
+import { combineURLs } from '../../utils/URL';
 import { AccessToken } from '../models/AccessToken';
 import { AccessTokenProvider } from '../models/AccessTokenProvider';
 import { OAuth2ClientCredentials } from '../models/OAuth2ClientCredentials';
@@ -7,22 +10,22 @@ import { OAuth2ClientCredentials } from '../models/OAuth2ClientCredentials';
  * @hidden
  */
 export class OAuth2Client implements AccessTokenProvider {
-  public client: AxiosInstance;
+  public httpClient: HttpClient;
 
   private clientCredentials: OAuth2ClientCredentials;
   private token: AccessToken;
   private tokenExpires: number;
   private inFlight: Promise<AccessToken>;
+  private authUrl: string;
 
   constructor(
     clientCredentials: OAuth2ClientCredentials,
     { authUrl = 'https://auth.adis.ws' },
-    config?: AxiosRequestConfig
+    httpClient: HttpClient
   ) {
-    config = config || {};
-    config.baseURL = authUrl;
-    this.client = axios.create(config);
+    this.authUrl = authUrl;
     this.clientCredentials = clientCredentials;
+    this.httpClient = httpClient;
   }
 
   /**
@@ -48,15 +51,24 @@ export class OAuth2Client implements AccessTokenProvider {
       '&client_secret=' +
       encodeURIComponent(this.clientCredentials.client_secret);
 
-    const request = this.client.post('/oauth/token', payload, {
+    const request = this.httpClient.request({
+      data: payload,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      },
+      method: HttpMethod.POST,
+      url: combineURLs(this.authUrl, '/oauth/token')
     });
 
     this.inFlight = request.then(
       (response): AccessToken => {
-        this.token = response.data;
+        if (typeof response.data !== 'object') {
+          throw new Error(
+            'Unexpected response format from /oauth/token endpoint'
+          );
+        }
+
+        this.token = response.data as any;
         this.tokenExpires = Date.now() + this.token.expires_in * 1000;
         this.inFlight = null;
         return this.token;

--- a/src/lib/utils/URL.ts
+++ b/src/lib/utils/URL.ts
@@ -1,0 +1,19 @@
+/**
+ * @hidden
+ */
+export function isAbsoluteURL(url): boolean {
+  return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url);
+}
+
+/**
+ * @hidden
+ */
+export function combineURLs(baseURL: string, relativeURL: string): string {
+  if (isAbsoluteURL(relativeURL)) {
+    return relativeURL;
+  } else {
+    return relativeURL
+      ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+      : baseURL;
+  }
+}


### PR DESCRIPTION
Allows users of the SDK to implement their own networking layer for the SDK. The original interfaces are intact and backwards compatible but they are now a default, axios based, implementation of an abstract class.

The motivation for this was to allow the SDK to be used in platforms that insist on using their own networking stack, specifically Zapier. Zapier implements its own authentication and network functions which are required to build an integration that follows their patterns and best practice.