### PR TITLE
fix(content-type-schema): removed the sort support from the sdk

### DIFF
--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -83,7 +83,7 @@ export class Hub extends HalResource {
        * Retrieves a list of Content Type Schemas associated with this Hub
        * @param options Pagination options
        */
-      list: (options?: Pageable & Sortable): Promise<Page<ContentTypeSchema>> =>
+      list: (options?: Pageable): Promise<Page<ContentTypeSchema>> =>
         this.fetchLinkedResource(
           'list-content-type-schemas',
           options,


### PR DESCRIPTION
Sort is currently not supported on the content-type-schema list endpoint