### PR TITLE
Add support for archive and unarchive hal links for Content

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -184,6 +184,14 @@ export const CONTENT_ITEM = {
       href:
         'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721'
     },
+    archive: {
+      href:
+        'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/archive'
+    },
+    unarchive: {
+      href:
+        'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/unarchive'
+    },
     delete: {
       href:
         'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/versions/1'
@@ -279,6 +287,14 @@ export const CONTENT_ITEM_WITH_LOCALE = {
     update: {
       href:
         'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721'
+    },
+    archive: {
+      href:
+        'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/archive'
+    },
+    unarchive: {
+      href:
+        'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/unarchive'
     },
     delete: {
       href:
@@ -460,6 +476,14 @@ export const CONTENT_TYPE_SCHEMA = {
     update: {
       href:
         'https://api.amplience.net/v2/content/content-type-schemas/5d4af55ced6688002869d808'
+    },
+    archive: {
+      href:
+        'https://api.amplience.net/v2/content/content-type-schemas/5d4af55ced6688002869d808/archive'
+    },
+    unarchive: {
+      href:
+        'https://api.amplience.net/v2/content/content-type-schemas/5d4af55ced6688002869d808/unarchive'
     },
     restore: {
       href:
@@ -959,6 +983,14 @@ export const CONTENT_TYPE = {
       href:
         'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c460'
     },
+    archive: {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c460/archive'
+    },
+    unarchive: {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c460/unarchive'
+    },
     'content-type': {
       href:
         'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c460'
@@ -1106,12 +1138,17 @@ export class DynamicContentFixtures {
     mocks
       .resource(CONTENT_ITEM)
       .nestedResource('content-item-version', { version: 1 }, CONTENT_ITEM)
-      .nestedUpdateResource('update', {}, CONTENT_ITEM_V2);
+      .nestedUpdateResource('update', {}, CONTENT_ITEM_V2)
+      .nestedCreateResource('archive', {}, CONTENT_ITEM)
+      .nestedCreateResource('unarchive', {}, CONTENT_ITEM);
 
     // Content type schemas
     mocks
       .resource(CONTENT_TYPE_SCHEMA)
-      .nestedUpdateResource('update', {}, CONTENT_TYPE_SCHEMA_V2);
+      .nestedUpdateResource('update', {}, CONTENT_TYPE_SCHEMA_V2)
+      .nestedCreateResource('archive', {}, CONTENT_TYPE_SCHEMA)
+      .nestedCreateResource('unarchive', {}, CONTENT_TYPE_SCHEMA);
+
     mocks.resource(
       CONTENT_TYPE_SCHEMA_V2,
       CONTENT_TYPE_SCHEMA_V2._links.self.href + '/2'
@@ -1175,6 +1212,8 @@ export class DynamicContentFixtures {
     mocks
       .resource(CONTENT_TYPE)
       .nestedUpdateResource('update', {}, CONTENT_TYPE_UPDATED)
+      .nestedCreateResource('archive', {}, CONTENT_TYPE)
+      .nestedCreateResource('unarchive', {}, CONTENT_TYPE)
       .nestedUpdateResource(
         'content-type-schema',
         {},

--- a/src/lib/model/ContentItem.spec.ts
+++ b/src/lib/model/ContentItem.spec.ts
@@ -37,6 +37,24 @@ test('update', async t => {
   t.is(update.version, contentItem.version + 1);
 });
 
+test('archive', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentItems.get(
+    'a87fd535-fb25-44ee-b687-0db72bbab721'
+  );
+  const archiveContentType = await result.related.archive();
+  t.is(archiveContentType.id, 'a87fd535-fb25-44ee-b687-0db72bbab721');
+});
+
+test('unarchive', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentItems.get(
+    'a87fd535-fb25-44ee-b687-0db72bbab721'
+  );
+  const unarchiveContentType = await result.related.unarchive();
+  t.is(unarchiveContentType.id, 'a87fd535-fb25-44ee-b687-0db72bbab721');
+});
+
 test('get repository', async t => {
   const client = new MockDynamicContent();
 

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -145,7 +145,29 @@ export class ContentItem extends HalResource {
      * to avoid overwriting other user's changes.
      */
     update: (mutation: ContentItem): Promise<ContentItem> =>
-      this.updateResource(mutation, ContentItem)
+      this.updateResource(mutation, ContentItem),
+
+    /**
+     * Archive content item
+     */
+    archive: (): Promise<ContentItem> =>
+      this.performActionThatReturnsResource(
+        'archive',
+        {},
+        { version: this.version },
+        ContentItem
+      ),
+
+    /**
+     * Unarchive content item
+     */
+    unarchive: (): Promise<ContentItem> =>
+      this.performActionThatReturnsResource(
+        'unarchive',
+        {},
+        { version: this.version },
+        ContentItem
+      )
   };
 }
 

--- a/src/lib/model/ContentType.spec.ts
+++ b/src/lib/model/ContentType.spec.ts
@@ -41,6 +41,20 @@ test('update', async t => {
   t.deepEqual(update.settings, mutation.settings);
 });
 
+test('archive', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentTypes.get('5be1d5134cedfd01c030c460');
+  const archiveContentType = await result.related.archive();
+  t.is(archiveContentType.id, '5be1d5134cedfd01c030c460');
+});
+
+test('unarchive', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentTypes.get('5be1d5134cedfd01c030c460');
+  const unarchiveContentType = await result.related.unarchive();
+  t.is(unarchiveContentType.id, '5be1d5134cedfd01c030c460');
+});
+
 test('contentTypeSchemas.get', async t => {
   const client = new MockDynamicContent();
 

--- a/src/lib/model/ContentType.ts
+++ b/src/lib/model/ContentType.ts
@@ -103,6 +103,18 @@ export class ContentType extends HalResource {
     update: (mutation: ContentType): Promise<ContentType> =>
       this.updateResource(mutation, ContentType),
 
+    /**
+     * Archive content type
+     */
+    archive: (): Promise<ContentType> =>
+      this.performActionThatReturnsResource('archive', {}, {}, ContentType),
+
+    /**
+     * Unarchive content type
+     */
+    unarchive: (): Promise<ContentType> =>
+      this.performActionThatReturnsResource('unarchive', {}, {}, ContentType),
+
     contentTypeSchema: {
       /**
        * Get the associated JSON schema document for a content type

--- a/src/lib/model/ContentTypeSchema.spec.ts
+++ b/src/lib/model/ContentTypeSchema.spec.ts
@@ -57,3 +57,27 @@ test('update a ContentTypeSchema', async t => {
   const createContentTypeSchema = await result.related.update(result);
   t.is(createContentTypeSchema.version, 2);
 });
+
+test('archive a ContentTypeSchema', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentTypeSchemas.get(
+    '5d4af55ced6688002869d808'
+  );
+  const archiveContentTypeSchema = await result.related.archive();
+  t.is(
+    archiveContentTypeSchema.schemaId,
+    'http://example.com/content-type-schema.json'
+  );
+});
+
+test('unarchive a ContentTypeSchema', async t => {
+  const client = new MockDynamicContent();
+  const result = await client.contentTypeSchemas.get(
+    '5d4af55ced6688002869d808'
+  );
+  const unarchiveContentTypeSchema = await result.related.unarchive();
+  t.is(
+    unarchiveContentTypeSchema.schemaId,
+    'http://example.com/content-type-schema.json'
+  );
+});

--- a/src/lib/model/ContentTypeSchema.ts
+++ b/src/lib/model/ContentTypeSchema.ts
@@ -69,7 +69,29 @@ export class ContentTypeSchema extends HalResource {
      * @param updated
      */
     update: (mutation: ContentTypeSchema): Promise<ContentTypeSchema> =>
-      this.updateResource(mutation, ContentTypeSchema)
+      this.updateResource(mutation, ContentTypeSchema),
+
+    /**
+     * Archive content type schema
+     */
+    archive: (): Promise<ContentTypeSchema> =>
+      this.performActionThatReturnsResource(
+        'archive',
+        {},
+        { version: this.version },
+        ContentTypeSchema
+      ),
+
+    /**
+     * Unarchive content type schema
+     */
+    unarchive: (): Promise<ContentTypeSchema> =>
+      this.performActionThatReturnsResource(
+        'unarchive',
+        {},
+        { version: this.version },
+        ContentTypeSchema
+      )
   };
 }
 


### PR DESCRIPTION
Rather simple - allows access to content's archive and unarchive links via their `.related` object. This PR adds this functionality to three different resource types:

- Content Type Schemas
- Content Types
- Content Items

There are tests for each to ensure that the correct link is called. From what me and QA have tested, all of these appear to be working properly. Attempting to archive content that is already archived (and vice versa for unarchiving) will throw a hal link permissions error. For some reason, Content Items just fail silently, but this seems to be intentional.