### PR TITLE
Folders: add proper pagination support to subfolder and subitem list

### DIFF
--- a/src/lib/model/Folder.ts
+++ b/src/lib/model/Folder.ts
@@ -1,7 +1,10 @@
 import { HalResource } from '../hal/models/HalResource';
+import { CURIEs } from '../hal/services/CURIEs';
 import { ContentItem, ContentItemsPage } from './ContentItem';
 import { ContentRepository } from './ContentRepository';
 import { Page } from './Page';
+import { Pageable } from './Pageable';
+import { Sortable } from './Sortable';
 
 export class Folder extends HalResource {
   public id?: string;
@@ -27,9 +30,12 @@ export class Folder extends HalResource {
 
       /**
        * Retrieves the list of sub-folders contained within this Folder
+       * @param options Pagination options
        */
-      list: (): Promise<Page<Folder>> =>
-        this.client.fetchResource(`folders/${this.id}/folders`, FoldersPage),
+      list: (options?: Pageable & Sortable): Promise<Page<Folder>> => {
+        const path = CURIEs.expand(`folders/${this.id}/folders`, options);
+        return this.client.fetchResource(path, FoldersPage);
+      },
 
       /**
        * Creates a folder beneath the folder
@@ -42,9 +48,10 @@ export class Folder extends HalResource {
     contentItems: {
       /**
        * Retrieves a list of Content Items stored within this Folder
+       * @param options Pagination options
        */
-      list: (): Promise<Page<ContentItem>> =>
-        this.fetchLinkedResource('content-items', {}, ContentItemsPage)
+      list: (options?: Pageable & Sortable): Promise<Page<ContentItem>> =>
+        this.fetchLinkedResource('content-items', options, ContentItemsPage)
     }
   };
 }

--- a/src/lib/model/Folder.ts
+++ b/src/lib/model/Folder.ts
@@ -33,7 +33,10 @@ export class Folder extends HalResource {
        * @param options Pagination options
        */
       list: (options?: Pageable & Sortable): Promise<Page<Folder>> => {
-        const path = CURIEs.expand(`folders/${this.id}/folders`, options);
+        const path = CURIEs.expand(
+          `folders/${this.id}/folders{?page,size,sort}`,
+          options
+        );
         return this.client.fetchResource(path, FoldersPage);
       },
 


### PR DESCRIPTION
While working with the folders api, I noticed I wasn't able to pass in any pagination options for listing subfolders or subitems, meaning that it just showed the first 20 items every time (could never see the ones past that point). This change allows pagination and sort options to be passed to the requests.