### PR TITLE
chore: github pr & issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+If you are asking a question rather than filing a bug, try one of these instead:
+- Ask a question on StackOverflow using the tag amplience-dynamic-content
+- Open a support ticket with Amplience Support
+- Contact your Amplience Customer Success representative
+- If you have found a bug please report it by opening an issue
+-->
+
+### Description
+<!-- Example: Error thrown when calling `new DynamicContent();`  -->
+
+#### Steps to Reproduce
+<!--
+Example:
+
+1. Create `new DynamicContent({})` 
+2. ....
+-->
+
+#### Expected Results
+<!-- Example: No error is throw -->
+
+#### Actual Results
+<!-- Example: Error is thrown -->
+
+### Affected browsers/environments
+<!-- Check all that apply -->
+- [ ] NodeJS 8.x
+- [ ] NodeJS 10.x
+- [ ] NodeJS 12.x
+
+<!-- Include absolute versions where possible -->
+
+### Versions
+- dc-management-sdk-js: vX.X.X
+
+### Other information
+
+<!-- Any other information that is important to this issue -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Pull request checklist
+
+Please check if your PR fulfills the following requirements:
+- [ ] Build (`npm run build`) was run locally and any changes were pushed
+- [ ] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
+- [ ] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
+- [ ] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification
+
+
+## Pull request type
+
+Please check the type of change your PR introduces:
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, renaming)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] Documentation content changes
+- [ ] Other (please describe): 
+
+
+## What is the current behaviour?
+<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
+
+
+## What is the new behaviour?
+<!-- Please describe the behaviour or changes that are being added by this PR. -->
+
+-
+-
+-
+
+## Does this introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+
+## Other information
+
+<!-- Any other information that is important to this PR -->
+


### PR DESCRIPTION
Add issue and pr templates that are used in the dc-delivery-sdk-js (tweaked to refer to dc-management-sdk-js)