### PR TITLE
refactor(curie): using import instead of require to avoid module bundler issues

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1511,12 +1511,10 @@ export class DynamicContentFixtures {
   }
 }
 
-// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
  * @hidden
  */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MockAdapter = require('axios-mock-adapter');
+import MockAdapter from 'axios-mock-adapter';
 
 /**
  * @hidden

--- a/src/lib/hal/models/HalResource.spec.ts
+++ b/src/lib/hal/models/HalResource.spec.ts
@@ -3,12 +3,10 @@ import { AxiosHttpClient } from '../../http/AxiosHttpClient';
 import { DefaultHalClient, HalClient } from '../services/HalClient';
 import { HalResource } from './HalResource';
 
-// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
  * @hidden
  */
-// eslint-disable-next-line
-const MockAdapter = require('axios-mock-adapter');
+import MockAdapter from 'axios-mock-adapter';
 
 /**
  * @hidden

--- a/src/lib/hal/services/CURIEs.ts
+++ b/src/lib/hal/services/CURIEs.ts
@@ -1,8 +1,8 @@
 /**
  * @hidden
  */
-// eslint-disable-next-line
-const template = require('url-template');
+
+import template from 'url-template';
 
 /**
  * @hidden

--- a/src/lib/hal/services/HalClient.spec.ts
+++ b/src/lib/hal/services/HalClient.spec.ts
@@ -6,12 +6,10 @@ import { ContentRepository } from '../../model/ContentRepository';
 import { Hub } from '../../model/Hub';
 import { DefaultHalClient, HalClient } from './HalClient';
 
-// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
  * @hidden
  */
-// eslint-disable-next-line
-const MockAdapter = require('axios-mock-adapter');
+import MockAdapter from 'axios-mock-adapter';
 
 /**
  * @hidden

--- a/src/lib/http/AxiosHttpClient.spec.ts
+++ b/src/lib/http/AxiosHttpClient.spec.ts
@@ -2,12 +2,10 @@ import test from 'ava';
 import { AxiosHttpClient } from './AxiosHttpClient';
 import { HttpMethod } from './HttpRequest';
 
-// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
  * @hidden
  */
-// eslint-disable-next-line
-const MockAdapter = require('axios-mock-adapter');
+import MockAdapter from 'axios-mock-adapter';
 
 test('client should use provided base url', async (t) => {
   const client = new AxiosHttpClient({

--- a/src/lib/oauth2/services/OAuth2Client.spec.ts
+++ b/src/lib/oauth2/services/OAuth2Client.spec.ts
@@ -2,12 +2,11 @@ import test from 'ava';
 import { AxiosHttpClient } from '../../http/AxiosHttpClient';
 import { OAuth2Client } from './OAuth2Client';
 
-// axios-mock-adaptor's typedefs are wrong preventing calling onGet with 3 args, this is a workaround
 /**
  * @hidden
  */
-// eslint-disable-next-line
-const MockAdapter = require('axios-mock-adapter');
+// tslint:disable-next-line
+import MockAdapter from 'axios-mock-adapter';
 
 test('get token should request a token on the first invocation', async (t) => {
   const httpClient = new AxiosHttpClient({});


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Module bundlers such as Rollup.js are unable to bundle the SDK (out the box) as the combination of import and require module syntax confuses the bundler (as the bundler determines which module system is being used). In cases where a project bundles the SDK for browser environments the require is not converted to be browser friendly, resulting in errors.


## What is the new behaviour?
The SDK has been update to only use `import` in all instances. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


