### PR TITLE
build(npm): added a prepare phase to build the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "all": "run-s reset build test doc:html",
     "prepare-patch-release": "run-s all version:patch doc:publish",
     "prepare-minor-release": "run-s all version:minor doc:publish",
-    "prepare-major-release": "run-s all version:major doc:publish"
+    "prepare-major-release": "run-s all version:major doc:publish",
+    "prepack": "npm ci && npm run build"
   },
   "scripts-info": {
     "info": "Display information about the package scripts",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [ ] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Using this repo as a npm git dependency fails as npm checks out the project and applies the '.npmignore' rule set --  ignores all .ts files and only includes .js files, which there are none.
Meaning your dependant application will fail.


## What is the new behaviour?
Adding  "npm ci && npm run build" in the prepack phase builds the lib before npm runs it local 'pack' command when using this repo as a git dependency.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

This change has been tested and verify using an external app running on Netlify, contact me directly for the example URL.

