### PR TITLE
feat(search indexes): include replicas option

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:lint": "eslint \"src/**/*.ts\" && prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava",
     "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch\"",
-    "cov": "run-s build test:unit cov:html && opn coverage/index.html",
+    "cov": "run-s build test:unit cov:html && open coverage/index.html",
     "cov:html": "nyc report --reporter=html",
     "cov:send": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "cov:check": "nyc report && nyc check-coverage --lines 80 --functions 80 --branches 80",

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -993,7 +993,7 @@ export const SEARCH_INDEX = {
     },
     'top-searches': {
       href:
-        'https://api.amplience.net/v2/content/algolia-search/00112233445566778899aabb/indexes/00112233445566778899aabb/analytics/top-searches{?clickAnalytics,orderBy,direction,startDate,endDate,limit,offset,tags}',
+        'https://api.amplience.net/v2/content/algolia-search/00112233445566778899aabb/indexes/00112233445566778899aabb/analytics/top-searches{?clickAnalytics,orderBy,direction,startDate,endDate,limit,offset,tags,includeReplicas}',
       templated: true,
     },
     'top-hits': {
@@ -1451,14 +1451,55 @@ export class DynamicContentFixtures {
       .nestedResource('stats', {}, SEARCH_INDEX_STATISTICS)
       .nestedCollection(
         'top-searches',
-        { clickAnalytics: false },
+        {
+          clickAnalytics: 'false',
+        },
         'top-searches',
         [SEARCH_INDEX_TOP_SEARCHES]
       )
-      .nestedCollection('top-hits', {}, 'top-hits', [SEARCH_INDEX_TOP_HITS])
-      .nestedCollection('top-hits', { search: 'term' }, 'top-hits', [
-        SEARCH_INDEX_TOP_HITS,
-      ])
+      .nestedCollection(
+        'top-searches',
+        {
+          clickAnalytics: 'true',
+          direction: 'asc',
+          endDate: '2020-12-31',
+          startDate: '2020-01-01',
+          includeReplicas: 'true',
+          limit: '10',
+          offset: '20',
+          orderBy: 'searchCount',
+          tags: 'additional_tags',
+        },
+        'top-searches',
+        [SEARCH_INDEX_TOP_SEARCHES]
+      )
+      .nestedCollection(
+        'top-hits',
+        {
+          endDate: '2020-12-31',
+          startDate: '2020-01-01',
+          includeReplicas: 'true',
+          limit: '10',
+          offset: '20',
+          tags: 'additional_tags',
+        },
+        'top-hits',
+        [SEARCH_INDEX_TOP_HITS]
+      )
+      .nestedCollection(
+        'top-hits',
+        {
+          search: 'term',
+          endDate: '2020-12-31',
+          startDate: '2020-01-01',
+          includeReplicas: 'true',
+          limit: '10',
+          offset: '20',
+          tags: 'additional_tags',
+        },
+        'top-hits',
+        [SEARCH_INDEX_TOP_HITS]
+      )
       .nestedUpdateResource('update', {}, SEARCH_INDEX_UPDATED)
       .nestedResource('settings', {}, SEARCH_INDEX_SETTINGS)
       .nestedUpdateResource(
@@ -1559,7 +1600,7 @@ import MockAdapter from 'axios-mock-adapter';
  * @hidden
  */
 export class MockDynamicContent extends DynamicContent {
-  public mock: any;
+  public mock: MockAdapter;
 
   constructor(
     clientCredentials?: OAuth2ClientCredentials,

--- a/src/lib/model/SearchIndex.spec.ts
+++ b/src/lib/model/SearchIndex.spec.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import { MockDynamicContent } from '../DynamicContent.mocks';
 import { AssignedContentType } from './AssignedContentType';
 import { SearchIndex } from './SearchIndex';
+import { SearchesOrderBy } from './SearchIndexTopSearches';
 
 test('get search index by id', async (t) => {
   const client = new MockDynamicContent();
@@ -143,7 +144,7 @@ test('delete an index object', async (t) => {
   );
 });
 
-test('get top-results analytics for a search index', async (t) => {
+test('get top-results analytics for a search index should default to clickAnalytics=false', async (t) => {
   const client = new MockDynamicContent();
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
   const searchIndex = await hub.related.searchIndexes.get(
@@ -154,27 +155,68 @@ test('get top-results analytics for a search index', async (t) => {
   t.is(item.search, 'q0');
   t.is(item.nbHits, 1);
   t.is(item.count, 1);
+  const getRequests = client.mock.history['get'];
+  const query = getRequests[getRequests.length - 1].url.split('?')[1];
+  t.is(query, 'clickAnalytics=false');
 });
 
-test('get top-hits analytics for a search index', async (t) => {
+test('get top-results analytics for a search index', async (t) => {
   const client = new MockDynamicContent();
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
   const searchIndex = await hub.related.searchIndexes.get(
     '00112233445566778899aabb'
   );
-  const result = await searchIndex.related['top-hits'].get({});
+  const result = await searchIndex.related['top-searches'].get({
+    clickAnalytics: true,
+    direction: 'asc',
+    endDate: '2020-12-31',
+    startDate: '2020-01-01',
+    includeReplicas: true,
+    limit: 10,
+    offset: 20,
+    orderBy: SearchesOrderBy.SEARCH_COUNT,
+    tags: 'additional_tags',
+  });
+  const item = result.getItems()[0];
+  t.is(item.search, 'q0');
+  t.is(item.nbHits, 1);
+  t.is(item.count, 1);
+});
+
+test('get top-hits analytics for a search index with no search term', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const searchIndex = await hub.related.searchIndexes.get(
+    '00112233445566778899aabb'
+  );
+  const result = await searchIndex.related['top-hits'].get({
+    endDate: '2020-12-31',
+    startDate: '2020-01-01',
+    includeReplicas: true,
+    limit: 10,
+    offset: 20,
+    tags: 'additional_tags',
+  });
   const item = result.getItems()[0];
   t.is(item.count, 123);
   t.is(item.hit, 'ObjectID');
 });
 
-test('get top-hits analytics for a search index for a given search term', async (t) => {
+test('get top-hits analytics for a search index for a search term', async (t) => {
   const client = new MockDynamicContent();
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
   const searchIndex = await hub.related.searchIndexes.get(
     '00112233445566778899aabb'
   );
-  const result = await searchIndex.related['top-hits'].get({ search: 'term' });
+  const result = await searchIndex.related['top-hits'].get({
+    search: 'term',
+    endDate: '2020-12-31',
+    startDate: '2020-01-01',
+    includeReplicas: true,
+    limit: 10,
+    offset: 20,
+    tags: 'additional_tags',
+  });
   const item = result.getItems()[0];
   t.is(item.count, 123);
   t.is(item.hit, 'ObjectID');

--- a/src/lib/model/SearchIndex.ts
+++ b/src/lib/model/SearchIndex.ts
@@ -156,6 +156,7 @@ export class SearchIndex extends HalResource {
         limit,
         offset,
         tags,
+        includeReplicas,
       }: {
         clickAnalytics?: boolean;
         orderBy?: SearchesOrderBy;
@@ -165,6 +166,7 @@ export class SearchIndex extends HalResource {
         limit?: number;
         offset?: number;
         tags?: string;
+        includeReplicas?: boolean;
       }): Promise<SearchIndexTopSearchesCollection> =>
         this.fetchLinkedResource(
           'top-searches',
@@ -177,6 +179,7 @@ export class SearchIndex extends HalResource {
             orderBy,
             startDate,
             tags,
+            includeReplicas,
           },
           SearchIndexTopSearchesCollection
         ),
@@ -190,6 +193,7 @@ export class SearchIndex extends HalResource {
         limit,
         offset,
         tags,
+        includeReplicas,
       }: {
         search?: string;
         startDate?: string;
@@ -197,6 +201,7 @@ export class SearchIndex extends HalResource {
         limit?: number;
         offset?: number;
         tags?: string;
+        includeReplicas?: boolean;
       }): Promise<SearchIndexTopHitsCollection> =>
         this.fetchLinkedResource(
           'top-hits',
@@ -207,6 +212,7 @@ export class SearchIndex extends HalResource {
             search,
             startDate,
             tags,
+            includeReplicas,
           },
           SearchIndexTopHitsCollection
         ),


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
No includeReplicas support
`npm run cov` fails to open coverage report


## What is the new behaviour?
- Added the `includeReplicas` param to the top-hits search indexes api
- fixed `npm run cov`
- improved code coverage

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
