### PR TITLE
feat: exporting search indexes classes and enums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,17 @@ export { ContentLink } from './lib/content/models/ContentLink';
 export { ContentLinkInstance } from './lib/content/models/ContentLink';
 export { Webhook } from './lib/model/Webhook';
 export { SearchIndex } from './lib/model/SearchIndex';
+export { SearchIndexSettings } from './lib/model/SearchIndexSettings';
+export {
+  SearchIndexStatistics,
+  SearchIndexStatisticsUsageMetric,
+  SearchIndexStatisticsUsage,
+} from './lib/model/SearchIndexStatistics';
+export { SearchIndexTopHits } from './lib/model/SearchIndexTopHits';
+export {
+  SearchIndexTopSearches,
+  SearchesOrderBy,
+} from './lib/model/SearchIndexTopSearches';
 export { WebhookSignature } from './lib/utils/WebhookSignature';
 export { Folder } from './lib/model/Folder';
 export { LocalizationJob } from './lib/model/LocalizationJob';

--- a/src/lib/model/SearchIndexStatistics.ts
+++ b/src/lib/model/SearchIndexStatistics.ts
@@ -1,11 +1,11 @@
 import { HalResource } from '../hal/models/HalResource';
 
-interface Usage {
-  averageResponseTime?: UsageMetric;
-  numberOfSearches?: UsageMetric;
+export interface SearchIndexStatisticsUsage {
+  averageResponseTime?: SearchIndexStatisticsUsageMetric;
+  numberOfSearches?: SearchIndexStatisticsUsageMetric;
 }
 
-interface UsageMetric {
+export interface SearchIndexStatisticsUsageMetric {
   unit?: string;
   duration?: number;
   value?: number;
@@ -33,5 +33,5 @@ export class SearchIndexStatistics extends HalResource {
   /**
    * Usage statistics for an index.
    */
-  public usage?: Usage;
+  public usage?: SearchIndexStatisticsUsage;
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
All SearchIndex related classes aren't exported


## What is the new behaviour?

- exports the search indexes related classes and enums


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

