### PR TITLE
fix(search indexes): adds all supplied parameters to a list request

### DIFF
--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -171,7 +171,7 @@ export class Hub extends HalResource {
       ): Promise<Page<SearchIndex>> =>
         this.fetchLinkedResource(
           'algolia-search-indexes',
-          options,
+          { parentId, projection, ...options },
           SearchIndexesPage
         ),
     },


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
`parentId` and `projection` are missing from the supplied parameters when calling the list indexes endpoint


## What is the new behaviour?
The aforementioned parameters have been included in the list indexes request.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Pointed at the search analytics branch to show current changes only

