### PR TITLE
feat(search indexes): adding users-count api call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export {
   SearchIndexTopFiltersNoResultSearch,
   SearchIndexTopFiltersNoResultSearchValue,
 } from './lib/model/SearchIndexTopFiltersNoResultSearch';
+export { SearchIndexUsersCount } from './lib/model/SearchIndexUsersCount';
 export { WebhookSignature } from './lib/utils/WebhookSignature';
 export { Folder } from './lib/model/Folder';
 export { LocalizationJob } from './lib/model/LocalizationJob';

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1011,6 +1011,11 @@ export const SEARCH_INDEX = {
         'https://api.amplience.net/v2/content/algolia-search/00112233445566778899aabb/indexes/00112233445566778899aabb/analytics/top-filters-no-result-search{?search,startDate,endDate,limit,offset,tags}',
       templated: true,
     },
+    'users-count': {
+      href:
+        'https://api.amplience.net/v2/content/algolia-search/00112233445566778899aabb/indexes/00112233445566778899aabb/analytics/users-count{?startDate,endDate,tags,includeReplicas}',
+      templated: true,
+    },
   },
 };
 
@@ -1095,6 +1100,38 @@ export const SEARCH_INDEX_TOP_FILTER_NO_RESULT_SEARCH = {
       value: 'apple',
     },
   ],
+};
+
+/**
+ * @hidden
+ */
+export const SEARCH_INDEX_USERS_COUNT = {
+  count: 1,
+  dates: [
+    {
+      count: 1,
+      date: '2020-08-01',
+    },
+  ],
+  _links: {
+    self: {
+      href:
+        'https://api.amplience.net/v2/content/algolia-search/5b32377e4cedfd01c45036d8/indexes/00112233445566778899aabb/users-count',
+    },
+    hub: {
+      href:
+        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8',
+    },
+    'users-count': {
+      href:
+        'https://api.amplience.net/v2/content/algolia-search/5b32377e4cedfd01c45036d8/indexes/00112233445566778899aabb/users-count{?startDate,toDate,tags,includeReplicas}',
+      templated: true,
+    },
+    index: {
+      href:
+        'https://api.amplience.net/v2/content/algolia-search/5b32377e4cedfd01c45036d8/indexes/00112233445566778899aabb',
+    },
+  },
 };
 
 /**
@@ -1559,6 +1596,16 @@ export class DynamicContentFixtures {
         },
         'top-filters-no-result-search',
         [SEARCH_INDEX_TOP_FILTER_NO_RESULT_SEARCH]
+      )
+      .nestedResource(
+        'users-count',
+        {
+          endDate: '2020-08-01',
+          startDate: '2020-08-01',
+          includeReplicas: 'true',
+          tags: 'additional_tags',
+        },
+        SEARCH_INDEX_USERS_COUNT
       )
       .nestedUpdateResource('update', {}, SEARCH_INDEX_UPDATED)
       .nestedResource('settings', {}, SEARCH_INDEX_SETTINGS)

--- a/src/lib/model/SearchIndex.spec.ts
+++ b/src/lib/model/SearchIndex.spec.ts
@@ -267,3 +267,20 @@ test('get top-filters-no-result-search analytics for a search index', async (t) 
     },
   ]);
 });
+
+test('get user count analytics for a search index', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const searchIndex = await hub.related.searchIndexes.get(
+    '00112233445566778899aabb'
+  );
+  const result = await searchIndex.related['users-count'].get({
+    endDate: '2020-08-01',
+    startDate: '2020-08-01',
+    includeReplicas: true,
+    tags: 'additional_tags',
+  });
+  t.is(result.count, 1);
+  t.is(result.dates[0].count, 1);
+  t.is(result.dates[0].date, '2020-08-01');
+});

--- a/src/lib/model/SearchIndex.ts
+++ b/src/lib/model/SearchIndex.ts
@@ -16,6 +16,7 @@ import {
 import { Sortable } from './Sortable';
 import { SearchIndexSearchesWithNoResultsCollection } from './SearchIndexSearchesWithNoResults';
 import { SearchIndexTopFiltersNoResultSearchCollection } from './SearchIndexTopFiltersNoResultSearch';
+import { SearchIndexUsersCount } from './SearchIndexUsersCount';
 
 /**
  * Class representing an Algolia Search Index.
@@ -279,6 +280,29 @@ export class SearchIndex extends HalResource {
             includeReplicas,
           },
           SearchIndexTopFiltersNoResultSearchCollection
+        ),
+    },
+    'users-count': {
+      get: ({
+        startDate,
+        endDate,
+        tags,
+        includeReplicas,
+      }: {
+        startDate?: string;
+        endDate?: string;
+        tags?: string;
+        includeReplicas?: boolean;
+      }): Promise<SearchIndexUsersCount> =>
+        this.fetchLinkedResource(
+          'users-count',
+          {
+            startDate,
+            endDate,
+            tags,
+            includeReplicas,
+          },
+          SearchIndexUsersCount
         ),
     },
   };

--- a/src/lib/model/SearchIndexUsersCount.ts
+++ b/src/lib/model/SearchIndexUsersCount.ts
@@ -1,0 +1,21 @@
+import { HalResource } from '../hal/models/HalResource';
+
+export interface SearchIndexUsersDateCount {
+  count: number;
+  date: string;
+}
+
+/**
+ * Class representing top hits  for an Algolia Search Index
+ */
+export class SearchIndexUsersCount extends HalResource {
+  /**
+   * The total user count for an index
+   */
+  public count: number;
+
+  /**
+   * The user count by date
+   */
+  public dates: SearchIndexUsersDateCount[];
+}

--- a/src/lib/model/SearchIndexUsersCount.ts
+++ b/src/lib/model/SearchIndexUsersCount.ts
@@ -6,7 +6,7 @@ export interface SearchIndexUsersDateCount {
 }
 
 /**
- * Class representing top hits  for an Algolia Search Index
+ * Class representing users count for an Search Index
  */
 export class SearchIndexUsersCount extends HalResource {
   /**


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
N/A


## What is the new behaviour?
 - adding index search analytics users-count api call

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

