### PR TITLE
feat(content types): get content type by id

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1972,6 +1972,7 @@ export class DynamicContentFixtures {
       .nestedCreateResource('create-event', {}, EVENT)
       .nestedCollection('webhooks', {}, 'webhooks', [WEBHOOK])
       .nestedCreateResource('create-webhook', {}, WEBHOOK)
+      .nestedResource('content-types', {}, CONTENT_TYPE)
       .nestedCollection('content-types', {}, 'content-types', [CONTENT_TYPE])
       .nestedCreateResource('register-content-type', {}, CONTENT_TYPE)
       .nestedCollection(

--- a/src/lib/model/Hub.spec.ts
+++ b/src/lib/model/Hub.spec.ts
@@ -43,6 +43,13 @@ test('list content types', async (t) => {
   t.is(result.getItems()[0].settings.label, 'Carousel');
 });
 
+test('get content type', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const result = await hub.related.contentTypes.get('5be1d5134cedfd01c030c460');
+  t.is(result.settings.label, 'Carousel');
+});
+
 test('register content type', async (t) => {
   const client = new MockDynamicContent();
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');

--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -124,6 +124,12 @@ export class Hub extends HalResource {
           resource,
           ContentType
         ),
+
+      /**
+       * Get a content type by its id
+       */
+      get: (id: string): Promise<ContentType> =>
+        this.client.fetchResource(`content-types/${id}`, ContentType),
     },
 
     editions: {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [X] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [X] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Unable to get Content Type by ID


## What is the new behaviour?
Added support to get Content Types by ID


## Does this introduce a breaking change?

- [ ] Yes
- [X] No
