### PR TITLE
feat: updating auth and icon urls

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1599,8 +1599,7 @@ export const CONTENT_TYPE = {
     icons: [
       {
         size: 256,
-        url:
-          'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
+        url: 'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
       },
     ],
     visualizations: [
@@ -1657,8 +1656,7 @@ const CONTENT_TYPE_UPDATED = {
     icons: [
       {
         size: 512,
-        url:
-          'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
+        url: 'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
       },
     ],
     label: 'New Label',

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1600,7 +1600,7 @@ export const CONTENT_TYPE = {
       {
         size: 256,
         url:
-          'http://apps.dev-artifacts.adis.ws/cms-icons/develop/v0.4.0/256/ca-types-grid-mixedmedia.png',
+          'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
       },
     ],
     visualizations: [
@@ -1658,7 +1658,7 @@ const CONTENT_TYPE_UPDATED = {
       {
         size: 512,
         url:
-          'http://apps.dev-artifacts.adis.ws/cms-icons/develop/v0.4.0/256/ca-types-grid-mixedmedia.png',
+          'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
       },
     ],
     label: 'New Label',

--- a/src/lib/DynamicContent.ts
+++ b/src/lib/DynamicContent.ts
@@ -33,7 +33,7 @@ export interface DynamicContentConfig {
 
   /**
    * URL used to connect to the Amplience OAuth API.
-   * This property defaults to 'https://auth.adis.ws' if not provided
+   * This property defaults to 'https://auth.amplience.net' if not provided
    */
   authUrl?: string;
 }
@@ -263,7 +263,7 @@ export class DynamicContent {
   ) {
     dcConfig = dcConfig || {};
     dcConfig.apiUrl = dcConfig.apiUrl || 'https://api.amplience.net/v2/content';
-    dcConfig.authUrl = dcConfig.authUrl || 'https://auth.adis.ws';
+    dcConfig.authUrl = dcConfig.authUrl || 'https://auth.amplience.net';
 
     let httpClientInstance: HttpClient;
     if (httpClient !== undefined && 'request' in httpClient) {

--- a/src/lib/model/ContentType.spec.ts
+++ b/src/lib/model/ContentType.spec.ts
@@ -23,7 +23,7 @@ test('update', async (t) => {
         {
           size: 512,
           url:
-            'http://apps.dev-artifacts.adis.ws/cms-icons/develop/v0.4.0/256/ca-types-grid-mixedmedia.png',
+            'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
         },
       ],
       label: 'New Label',
@@ -86,7 +86,7 @@ test('toJson should copy resource attributes', async (t) => {
         {
           size: 256,
           url:
-            'http://apps.dev-artifacts.adis.ws/cms-icons/develop/v0.4.0/256/ca-types-grid-mixedmedia.png',
+            'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
         },
       ],
       label: 'Carousel',

--- a/src/lib/model/ContentType.spec.ts
+++ b/src/lib/model/ContentType.spec.ts
@@ -22,8 +22,7 @@ test('update', async (t) => {
       icons: [
         {
           size: 512,
-          url:
-            'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
+          url: 'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
         },
       ],
       label: 'New Label',
@@ -85,8 +84,7 @@ test('toJson should copy resource attributes', async (t) => {
       icons: [
         {
           size: 256,
-          url:
-            'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
+          url: 'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
         },
       ],
       label: 'Carousel',

--- a/src/lib/oauth2/services/OAuth2Client.spec.ts
+++ b/src/lib/oauth2/services/OAuth2Client.spec.ts
@@ -22,7 +22,7 @@ test('get token should request a token on the first invocation', async (t) => {
   const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .reply(200, {
@@ -48,7 +48,7 @@ test('get token should cache tokens', async (t) => {
   const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .reply(200, {
@@ -61,7 +61,7 @@ test('get token should cache tokens', async (t) => {
 
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .reply(200, {
@@ -90,7 +90,7 @@ test('cached tokens should expire', async (t) => {
   const mock = new MockAdapter(httpClient.client);
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .reply(200, {
@@ -103,7 +103,7 @@ test('cached tokens should expire', async (t) => {
 
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .reply(200, {
@@ -133,7 +133,7 @@ test('only one token refresh should be in flight at once', async (t) => {
 
   mock
     .onPost(
-      'https://auth.adis.ws/oauth/token',
+      'https://auth.amplience.net/oauth/token',
       'grant_type=client_credentials&client_id=client_id&client_secret=client_secret'
     )
     .replyOnce(200, {

--- a/src/lib/oauth2/services/OAuth2Client.ts
+++ b/src/lib/oauth2/services/OAuth2Client.ts
@@ -19,7 +19,7 @@ export class OAuth2Client implements AccessTokenProvider {
 
   constructor(
     clientCredentials: OAuth2ClientCredentials,
-    { authUrl = 'https://auth.adis.ws' },
+    { authUrl = 'https://auth.amplience.net' },
     httpClient: HttpClient
   ) {
     this.authUrl = authUrl;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?

- `authUrl` points to `auth.adis.ws`
- card icons point to `http://apps.dev-artifacts.adis.ws',


## What is the new behaviour?
- `authUrl` now points to `auth.amplience.net`
- card icons now point to `bigcontent.io'

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
