### PR TITLE
fix(content items): make locale nullable

### DIFF
--- a/src/lib/model/ContentItem.spec.ts
+++ b/src/lib/model/ContentItem.spec.ts
@@ -140,3 +140,15 @@ test('assign a workflow state', async (t) => {
   );
   t.is(updatedContentItem.workflow.state, workflowState.id);
 });
+
+test('locale should not be required', async (t) => {
+  const item = new ContentItem({
+    label: 'New Label',
+    locale: 'en-GB',
+  });
+
+  item.locale = undefined;
+
+  const json = item.toJSON();
+  t.is(json.locale, undefined);
+});

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -44,7 +44,7 @@ abstract class BaseContentItem extends HalResource {
   /**
    * Locale
    */
-  public locale: string;
+  public locale?: string;
 
   /**
    * Unique id used by client applications to request the content from the delivery API


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Locale is not present on the ContentItem type, but it is regularly undefined when returned by DC.


## What is the new behaviour?
The type definition now allows `locale` to be undefin

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This may cause typescript compilers to require a null check. I'm not sure if this counts as a breaking change, feel free to comment if it is.

## Other information

Needed for `fix/locale` over in `dc-cli`
