### PR TITLE
feat(webhooks): add webhook properties for headers, method, filters and customPayload

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1544,7 +1544,7 @@ export const WEBHOOK = {
   },
 };
 
-export const CREATED_WEBHOOK = {
+export const WEBHOOK_WITH_EXTRAS = {
   id: '5a497a000000000000000000',
   label: 'Unit Test',
   events: ['dynamic-content.content-item.created'],
@@ -2282,7 +2282,7 @@ export class DynamicContentFixtures {
       .nestedCollection('events', {}, 'events', [EVENT])
       .nestedCreateResource('create-event', {}, EVENT)
       .nestedCollection('webhooks', {}, 'webhooks', [WEBHOOK])
-      .nestedCreateResource('create-webhook', {}, CREATED_WEBHOOK)
+      .nestedCreateResource('create-webhook', {}, WEBHOOK_WITH_EXTRAS)
       .nestedCollection('workflow-states', {}, 'workflow-states', [
         WORKFLOW_STATE,
       ])
@@ -2569,7 +2569,10 @@ export class DynamicContentFixtures {
       .nestedResource('content-type-schema', {}, CONTENT_TYPE_CACHED_SCHEMA);
 
     // Webhooks
-    mocks.resource(WEBHOOK).nestedResource('hub', {}, HUB);
+    mocks
+      .resource(WEBHOOK)
+      .nestedResource('hub', {}, HUB)
+      .nestedUpdateResource('update', {}, WEBHOOK_WITH_EXTRAS);
 
     // Workflow States
     mocks

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1544,6 +1544,98 @@ export const WEBHOOK = {
   },
 };
 
+export const CREATED_WEBHOOK = {
+  id: '5a497a000000000000000000',
+  label: 'Unit Test',
+  events: ['dynamic-content.content-item.created'],
+  active: true,
+  handlers: ['http://example.com/webhook'],
+  notifications: [],
+  secret: 'SECRET',
+  createdDate: '2021-04-20T08:08:36.678Z',
+  lastModifiedDate: '2021-04-20T08:08:36.678Z',
+  headers: [
+    {
+      key: 'X-Secret',
+      value: null,
+      secret: true,
+    },
+    {
+      key: 'X-Header',
+      value: 'abc123',
+      secret: null,
+    },
+  ],
+  filters: [
+    {
+      type: 'equal',
+      arguments: [
+        {
+          jsonPath: '$.payload.id',
+        },
+        {
+          value: 'abc',
+        },
+      ],
+    },
+    {
+      type: 'in',
+      arguments: [
+        {
+          jsonPath: '$.payload.id',
+        },
+        {
+          value: ['abc', 'def'],
+        },
+      ],
+    },
+    {
+      type: 'equal',
+      arguments: [
+        {
+          jsonPath: '$.payload.not_present',
+        },
+        {
+          value: '123',
+        },
+      ],
+    },
+  ],
+  customPayload: {
+    type: 'text/x-handlebars-template',
+    value:
+      '{{#withDeliveryContentItem contentItemId=payload.id account="myAccountId" stagingEnvironment="myVseUrl"}}{{{JSONstringify this}}}{{/withDeliveryContentItem}}',
+  },
+  method: 'POST',
+  _links: {
+    self: {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
+    },
+    hub: {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8',
+    },
+    requests: {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000/requests{?cursor,limit,excludeStatus}',
+      templated: true,
+    },
+    'event-types': {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/event-types',
+    },
+    update: {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
+    },
+    delete: {
+      href:
+        'https://api.amplience-dev.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
+    },
+  },
+};
+
 /**
  * @hidden
  */
@@ -2190,7 +2282,7 @@ export class DynamicContentFixtures {
       .nestedCollection('events', {}, 'events', [EVENT])
       .nestedCreateResource('create-event', {}, EVENT)
       .nestedCollection('webhooks', {}, 'webhooks', [WEBHOOK])
-      .nestedCreateResource('create-webhook', {}, WEBHOOK)
+      .nestedCreateResource('create-webhook', {}, CREATED_WEBHOOK)
       .nestedCollection('workflow-states', {}, 'workflow-states', [
         WORKFLOW_STATE,
       ])

--- a/src/lib/model/Webhook.spec.ts
+++ b/src/lib/model/Webhook.spec.ts
@@ -2,30 +2,13 @@ import test from 'ava';
 import { MockDynamicContent } from '../DynamicContent.mocks';
 import { Webhook } from './Webhook';
 
-test('get webhook by id', async (t) => {
-  const client = new MockDynamicContent();
-  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
-  const result = await hub.related.webhooks.get('5a497a000000000000000000');
-  t.is(result.label, 'myWebhookSubscription');
-});
-
-test('list webhooks', async (t) => {
-  const client = new MockDynamicContent();
-  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
-  const webhooks = await hub.related.webhooks.list();
-  t.is(webhooks.getItems()[0].label, 'myWebhookSubscription');
-});
-
-test('create webhook', async (t) => {
-  const client = new MockDynamicContent();
-  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
-  const webhook = new Webhook();
-  webhook.active = true;
-  webhook.label = 'Unit Test';
-  webhook.handlers = ['http://example.com/webhook'];
-  webhook.method = 'POST';
-  webhook.events = ['dynamic-content.content-item.created'];
-  webhook.filters = [
+const FIXTURE_WEBHOOK_WITH_EXTRA_PROPS = new Webhook({
+  active: true,
+  label: 'Unit Test',
+  handlers: ['http://example.com/webhook'],
+  method: 'POST',
+  events: ['dynamic-content.content-item.created'],
+  filters: [
     {
       type: 'equal',
       arguments: [
@@ -59,8 +42,8 @@ test('create webhook', async (t) => {
         },
       ],
     },
-  ];
-  webhook.headers = [
+  ],
+  headers: [
     {
       key: 'X-Secret',
       value: 'abc123',
@@ -70,35 +53,62 @@ test('create webhook', async (t) => {
       key: 'X-Header',
       value: 'abc123',
     },
-  ];
-  webhook.customPayload = {
+  ],
+  customPayload: {
     type: 'text/x-handlebars-template',
     value:
       '{{#withDeliveryContentItem contentItemId=payload.id account="myAccountId" stagingEnvironment="myVseUrl"}}{{{JSONstringify this}}}{{/withDeliveryContentItem}}',
-  };
-  webhook.secret = 'SECRET';
-  const newWebhook = await hub.related.webhooks.create(webhook);
+  },
+  secret: 'SECRET',
+});
+
+test('get webhook by id', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const result = await hub.related.webhooks.get('5a497a000000000000000000');
+  t.is(result.label, 'myWebhookSubscription');
+});
+
+test('list webhooks', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const webhooks = await hub.related.webhooks.list();
+  t.is(webhooks.getItems()[0].label, 'myWebhookSubscription');
+});
+
+test('create webhook', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+
+  const newWebhook = await hub.related.webhooks.create(
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS
+  );
+
   const postRequests = client.mock.history['post'];
   const createWebhook = postRequests[postRequests.length - 1];
+
   // validate the request
   const jsonBody = JSON.parse(createWebhook.data);
-  t.is(jsonBody.active, webhook.active);
-  t.is(jsonBody.label, webhook.label);
-  t.deepEqual(jsonBody.handlers, webhook.handlers);
-  t.is(jsonBody.method, webhook.method);
-  t.deepEqual(jsonBody.events, webhook.events);
-  t.deepEqual(jsonBody.filters, webhook.filters);
-  t.deepEqual(jsonBody.headers, webhook.headers);
-  t.deepEqual(jsonBody.customPayload, webhook.customPayload);
-  t.is(jsonBody.secret, webhook.secret);
+  t.is(jsonBody.active, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.active);
+  t.is(jsonBody.label, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.label);
+  t.deepEqual(jsonBody.handlers, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.handlers);
+  t.is(jsonBody.method, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.method);
+  t.deepEqual(jsonBody.events, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.events);
+  t.deepEqual(jsonBody.filters, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.filters);
+  t.deepEqual(jsonBody.headers, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.headers);
+  t.deepEqual(
+    jsonBody.customPayload,
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.customPayload
+  );
+  t.is(jsonBody.secret, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.secret);
 
   // validate the response
-  t.is(newWebhook.active, webhook.active);
-  t.is(newWebhook.label, webhook.label);
-  t.deepEqual(newWebhook.handlers, webhook.handlers);
-  t.is(newWebhook.method, webhook.method);
-  t.deepEqual(newWebhook.events, webhook.events);
-  t.deepEqual(newWebhook.filters, webhook.filters);
+  t.is(newWebhook.active, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.active);
+  t.is(newWebhook.label, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.label);
+  t.deepEqual(newWebhook.handlers, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.handlers);
+  t.is(newWebhook.method, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.method);
+  t.deepEqual(newWebhook.events, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.events);
+  t.deepEqual(newWebhook.filters, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.filters);
   t.deepEqual(newWebhook.headers, [
     {
       key: 'X-Secret',
@@ -111,8 +121,67 @@ test('create webhook', async (t) => {
       secret: false,
     },
   ]);
-  t.deepEqual(newWebhook.customPayload, webhook.customPayload);
-  t.is(newWebhook.secret, webhook.secret);
+  t.deepEqual(
+    newWebhook.customPayload,
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.customPayload
+  );
+  t.is(newWebhook.secret, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.secret);
+});
+
+test('update webhook', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const webhookList = await hub.related.webhooks.list();
+
+  const updatedWebhook = await webhookList
+    .getItems()[0] // 1st webhook
+    .related.update(FIXTURE_WEBHOOK_WITH_EXTRA_PROPS);
+
+  const patchRequests = client.mock.history['patch'];
+  const updatedWebhookRequest = patchRequests[patchRequests.length - 1];
+
+  // validate the request
+  const jsonBody = JSON.parse(updatedWebhookRequest.data);
+  t.is(jsonBody.active, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.active);
+  t.is(jsonBody.label, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.label);
+  t.deepEqual(jsonBody.handlers, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.handlers);
+  t.is(jsonBody.method, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.method);
+  t.deepEqual(jsonBody.events, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.events);
+  t.deepEqual(jsonBody.filters, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.filters);
+  t.deepEqual(jsonBody.headers, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.headers);
+  t.deepEqual(
+    jsonBody.customPayload,
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.customPayload
+  );
+  t.is(jsonBody.secret, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.secret);
+
+  // validate the response
+  t.is(updatedWebhook.active, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.active);
+  t.is(updatedWebhook.label, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.label);
+  t.deepEqual(
+    updatedWebhook.handlers,
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.handlers
+  );
+  t.is(updatedWebhook.method, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.method);
+  t.deepEqual(updatedWebhook.events, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.events);
+  t.deepEqual(updatedWebhook.filters, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.filters);
+  t.deepEqual(updatedWebhook.headers, [
+    {
+      key: 'X-Secret',
+      value: null, // value will be null a secret = true
+      secret: true,
+    },
+    {
+      key: 'X-Header',
+      value: 'abc123',
+      secret: false,
+    },
+  ]);
+  t.deepEqual(
+    updatedWebhook.customPayload,
+    FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.customPayload
+  );
+  t.is(updatedWebhook.secret, FIXTURE_WEBHOOK_WITH_EXTRA_PROPS.secret);
 });
 
 test('delete webhook', async (t) => {

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -28,17 +28,17 @@ export class Webhook extends HalResource {
   public handlers?: string[];
 
   /**
-   * List of custom webhook headers
+   * List of custom webhook headers to be send with webhook.
    */
   public headers?: WebhookHeader[];
 
   /**
-   * List of filters to apply to the webhook before sending
+   * List of filters used to gate sending of webhooks.
    */
   public filters?: WebhookFilter[];
 
   /**
-   * The HTTP method the webhook should use to communicate with the endpoint.
+   * The HTTP method the webhook should use to communicate with the handlers.
    */
   public method?: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -129,7 +129,7 @@ export type WebhookFilterJSONPathArgument = {
  * A value argument.
  */
 export type WebhookFilterValueArgument = {
-  value: string;
+  value: string | string[];
 };
 
 /**

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -4,7 +4,7 @@ import { Page } from './Page';
 
 /**
  * Class representing the [Webhook](https://amplience.com/docs/api/dynamic-content/management/#tag/Webhooks) resource.
- * A WebHook is an HTTP callback: an HTTP POST that occurs when something happens; a simple event-notification via HTTP POST.
+ * A Webhook is a HTTP callback: a HTTP request that occurs when something happens; a simple event-notification via the HTTP protocol.
  */
 export class Webhook extends HalResource {
   /**
@@ -28,7 +28,7 @@ export class Webhook extends HalResource {
   public handlers?: string[];
 
   /**
-   * List of custom webhook headers to be send with webhook.
+   * List of custom webhook headers to be sent.
    */
   public headers?: WebhookHeader[];
 
@@ -38,7 +38,7 @@ export class Webhook extends HalResource {
   public filters?: WebhookFilter[];
 
   /**
-   * The HTTP method the webhook should use to communicate with the handlers.
+   * The webhooks HTTP method.
    */
   public method?: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -102,12 +102,14 @@ export type WebhookHeader = {
    * The header
    */
   key: string;
+
   /**
-   * The headers value.
+   * The header's value.
    */
   value: string;
+
   /**
-   * Is the header a secret.
+   * Indicates this header value is sensitive.
    */
   secret?: boolean;
 };
@@ -117,24 +119,25 @@ export type WebhookHeader = {
  */
 export type WebhookCustomPayload = {
   /**
-   * What type of custom payload format being used.
+   * MIME type of the custom payload.
    */
   type: 'text/x-handlebars-template';
 
   /**
-   * The shape of the custom payload.
+   * Custom payload.
    */
   value: string;
 };
 
 /**
- * A webhook filter to allow for body to be interrogated to control whether a webhook is sent or not.
+ * A webhook filter.
  */
 export type WebhookFilter = {
   /**
-   * The how will the filter arguments be treated.
+   * The type of filter.
    */
   type: 'equal' | 'in';
+
   /**
    * The arguments for the filter.
    */

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -69,6 +69,19 @@ export class Webhook extends HalResource {
 
     delete: (): Promise<void> => this.deleteResource(),
   };
+
+  public parse(data: unknown): void {
+    super.parse(data);
+
+    if (this.headers) {
+      this.headers.forEach((header) => {
+        // secret can come back as null, lets convert this to false
+        if (header.secret == null) {
+          header.secret = false;
+        }
+      });
+    }
+  }
 }
 
 /**
@@ -86,7 +99,7 @@ export type WebhookHeader = {
   /**
    * Is the header a secret.
    */
-  secret: boolean;
+  secret?: boolean;
 };
 
 /**
@@ -105,7 +118,7 @@ export type WebhookCustomPayload = {
 };
 
 /**
- * A webhook filter to allow for body to be interigated to control whether a webhook is sent or not.
+ * A webhook filter to allow for body to be interrogated to control whether a webhook is sent or not.
  */
 export type WebhookFilter = {
   /**
@@ -115,7 +128,7 @@ export type WebhookFilter = {
   /**
    * The arguments for the filter.
    */
-  arguments: (WebhookFilterJSONPathArgument | WebhookFilterValueArgument)[];
+  arguments: [WebhookFilterJSONPathArgument, WebhookFilterValueArgument];
 };
 
 /**

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -67,7 +67,17 @@ export class Webhook extends HalResource {
      */
     hub: (): Promise<Hub> => this.fetchLinkedResource('hub', {}, Hub),
 
+    /**
+     * Delete Webhook
+     */
     delete: (): Promise<void> => this.deleteResource(),
+
+    /**
+     * Updates this Webhook with the changes in the mutation parameter.
+     * @param mutation
+     */
+    update: (mutation: Webhook): Promise<Webhook> =>
+      this.updateResource(mutation, Webhook),
   };
 
   public parse(data: unknown): void {

--- a/src/lib/model/Webhook.ts
+++ b/src/lib/model/Webhook.ts
@@ -28,6 +28,26 @@ export class Webhook extends HalResource {
   public handlers?: string[];
 
   /**
+   * List of custom webhook headers
+   */
+  public headers?: WebhookHeader[];
+
+  /**
+   * List of filters to apply to the webhook before sending
+   */
+  public filters?: WebhookFilter[];
+
+  /**
+   * The HTTP method the webhook should use to communicate with the endpoint.
+   */
+  public method?: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+  /**
+   * A customized payload format.
+   */
+  public customPayload?: WebhookCustomPayload;
+
+  /**
    * Enables or disables the webhook
    */
   public active?: boolean;
@@ -50,6 +70,67 @@ export class Webhook extends HalResource {
     delete: (): Promise<void> => this.deleteResource(),
   };
 }
+
+/**
+ * A custom webhook header which will be sent along with a webhook.
+ */
+export type WebhookHeader = {
+  /**
+   * The header
+   */
+  key: string;
+  /**
+   * The headers value.
+   */
+  value: string;
+  /**
+   * Is the header a secret.
+   */
+  secret: boolean;
+};
+
+/**
+ * A custom payload format for the webhook.
+ */
+export type WebhookCustomPayload = {
+  /**
+   * What type of custom payload format being used.
+   */
+  type: 'text/x-handlebars-template';
+
+  /**
+   * The shape of the custom payload.
+   */
+  value: string;
+};
+
+/**
+ * A webhook filter to allow for body to be interigated to control whether a webhook is sent or not.
+ */
+export type WebhookFilter = {
+  /**
+   * The how will the filter arguments be treated.
+   */
+  type: 'equal' | 'in';
+  /**
+   * The arguments for the filter.
+   */
+  arguments: (WebhookFilterJSONPathArgument | WebhookFilterValueArgument)[];
+};
+
+/**
+ * A JSON Path argument.
+ */
+export type WebhookFilterJSONPathArgument = {
+  jsonPath: string;
+};
+
+/**
+ * A value argument.
+ */
+export type WebhookFilterValueArgument = {
+  value: string;
+};
 
 /**
  * @hidden


### PR DESCRIPTION
Here I added a number of additional properties to the `Webhook` model.

I don't believe I have visibility into all of the potential `Webhook` filter `type`s, the only value I've seen in the interface is `in` and `equal`.

Similarly, I'm not sure if there are other `customPayload` types other than `text/x-handlebars-template`.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
(**Note: There are a number of warnings, 44 I believe, but I don't believe this PR adds any**)
- [X] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [X] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?

Currently unable to specify Webhook models `method`, `headers`, `customPayload`, or `filters`.

## What is the new behaviour?

- All of the above properties now exist on the typescript definition / class
- These work / are testing with the current API and allow these values to be set in the Amplience backend

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

I did not add additional tests as it didn't appear to be something currently done with `Webhook`s or in other places where types are simply being added.


Refs #82 