### PR TITLE
feat: include archived in status enum, add it to content type and schema

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -554,6 +554,7 @@ export const CONTENT_TYPE_SCHEMA = {
   lastModifiedDate: '2018-06-26T12:54:16.216Z',
   version: 1,
   id: '5d4af55ced6688002869d808',
+  status: 'ACTIVE',
   _links: {
     self: {
       href:
@@ -1686,6 +1687,7 @@ export const CONTENT_ITEM_WITH_WORKFLOW_STATE = {
 export const CONTENT_TYPE = {
   id: '5be1d5134cedfd01c030c460',
   contentTypeUri: 'http://deliver.bigcontent.io/schema/carousel.json',
+  status: 'ACTIVE',
   settings: {
     label: 'Carousel',
     icons: [

--- a/src/lib/model/ContentType.spec.ts
+++ b/src/lib/model/ContentType.spec.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import { MockDynamicContent } from '../DynamicContent.mocks';
 import { ContentType } from './ContentType';
 import { ContentTypeCachedSchema } from './ContentTypeCachedSchema';
+import { Status } from './Status';
 
 test('get content type by id', async (t) => {
   const client = new MockDynamicContent();
@@ -10,6 +11,7 @@ test('get content type by id', async (t) => {
     result.contentTypeUri,
     'http://deliver.bigcontent.io/schema/carousel.json'
   );
+  t.is(result.status, Status.ACTIVE);
 });
 
 test('update', async (t) => {
@@ -80,6 +82,7 @@ test('toJson should copy resource attributes', async (t) => {
   t.deepEqual(resource.toJson(), {
     contentTypeUri: 'http://deliver.bigcontent.io/schema/carousel.json',
     id: '5be1d5134cedfd01c030c460',
+    status: Status.ACTIVE,
     settings: {
       icons: [
         {

--- a/src/lib/model/ContentType.ts
+++ b/src/lib/model/ContentType.ts
@@ -1,6 +1,7 @@
 import { HalResource } from '../hal/models/HalResource';
 import { ContentTypeCachedSchema } from './ContentTypeCachedSchema';
 import { Page } from './Page';
+import { Status } from './Status';
 
 export interface ContentTypeIcon {
   /**
@@ -92,6 +93,11 @@ export class ContentType extends HalResource {
    * Object containing display settings for the content type
    */
   public settings?: ContentTypeSettings;
+
+  /**
+   * Lifecycle status of the content type
+   */
+  public status: Status;
 
   /**
    * Resources and actions related to a ContentType

--- a/src/lib/model/ContentTypeSchema.spec.ts
+++ b/src/lib/model/ContentTypeSchema.spec.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { MockDynamicContent } from '../DynamicContent.mocks';
 import { ContentTypeSchema } from './ContentTypeSchema';
+import { Status } from './Status';
 
 test('list ContentTypeSchemas for a Hub', async (t) => {
   const client = new MockDynamicContent();
@@ -18,6 +19,7 @@ test('get a ContentTypeSchema', async (t) => {
     '5d4af55ced6688002869d808'
   );
   t.is(result.schemaId, 'http://example.com/content-type-schema.json');
+  t.is(result.status, Status.ACTIVE);
 });
 
 test('get a version ContentTypeSchema', async (t) => {

--- a/src/lib/model/ContentTypeSchema.ts
+++ b/src/lib/model/ContentTypeSchema.ts
@@ -1,6 +1,7 @@
 import { HalResource } from '../hal/models/HalResource';
 import { Hub } from './Hub';
 import { Page } from './Page';
+import { Status } from './Status';
 
 /**
  * Supported validation levels
@@ -60,6 +61,11 @@ export class ContentTypeSchema extends HalResource {
    * Timestamp representing when the content item was last updated in ISO 8601 format
    */
   public lastModifiedDate?: string;
+
+  /**
+   * Lifecycle status of the content type schema
+   */
+  public status: Status;
 
   /**
    * Resources and actions related to a ContentTypeSchema

--- a/src/lib/model/Status.ts
+++ b/src/lib/model/Status.ts
@@ -3,5 +3,6 @@
  */
 export enum Status {
   ACTIVE = 'ACTIVE',
+  ARCHIVED = 'ARCHIVED',
   DELETED = 'DELETED',
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
The `Status` enum is not present on Content Types, and Content Type Schemas. It's also missing the `ARCHIVED` status, used by many of the existing types using this enum such as content items.

## What is the new behaviour?
The `status` property has been added to content types and schemas. The `ARCHIVED` status has been added to the enum.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

