### PR TITLE
feat: implement fetching webhooks for search index assigned content types

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -1537,7 +1537,7 @@ export const ASSIGNED_CONTENT_TYPE = {
     },
     webhook: {
       href:
-        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/00112233445566778899aabb',
+        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
     },
     'recreate-webhook': {
       href:
@@ -1545,7 +1545,11 @@ export const ASSIGNED_CONTENT_TYPE = {
     },
     'active-content-webhook': {
       href:
-        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/00112233445566778899aabb',
+        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
+    },
+    'archived-content-webhook': {
+      href:
+        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/webhooks/5a497a000000000000000000',
     },
     'recreate-active-content-webhook': {
       href:

--- a/src/lib/model/AssignedContentType.spec.ts
+++ b/src/lib/model/AssignedContentType.spec.ts
@@ -39,3 +39,48 @@ test('recreate webhook for an assigned content type', async (t) => {
   );
   return t.notThrowsAsync(result.related.recreateWebhook());
 });
+
+test('get webhook for an assigned content type', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const searchIndex = await hub.related.searchIndexes.get(
+    '00112233445566778899aabb'
+  );
+  const result = await searchIndex.related.assignedContentTypes.get(
+    '00112233445566778899aabb'
+  );
+
+  const webhook = await result.related.webhook();
+
+  t.is(webhook.id, '5a497a000000000000000000');
+});
+
+test('get active content webhook for an assigned content type', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const searchIndex = await hub.related.searchIndexes.get(
+    '00112233445566778899aabb'
+  );
+  const result = await searchIndex.related.assignedContentTypes.get(
+    '00112233445566778899aabb'
+  );
+
+  const webhook = await result.related.activeContentWebhook();
+
+  t.is(webhook.id, '5a497a000000000000000000');
+});
+
+test('get archived content webhook for an assigned content type', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const searchIndex = await hub.related.searchIndexes.get(
+    '00112233445566778899aabb'
+  );
+  const result = await searchIndex.related.assignedContentTypes.get(
+    '00112233445566778899aabb'
+  );
+
+  const webhook = await result.related.archivedContentWebhook();
+
+  t.is(webhook.id, '5a497a000000000000000000');
+});

--- a/src/lib/model/AssignedContentType.ts
+++ b/src/lib/model/AssignedContentType.ts
@@ -26,21 +26,39 @@ export class AssignedContentType extends HalResource {
    */
   public lastModifiedDate?: string;
 
+  /**
+   * Resources and actions related to an Assigned Content Type.
+   */
   public readonly related = {
+    /**
+     * Unassigns the content type from the search index.
+     */
     unassign: (id: string): Promise<void> =>
       this.deleteLinkedResource('unassign', {
         id,
       }),
 
+    /**
+     * Recreates the webhooks for this Assigned Content Type.
+     */
     recreateWebhook: (): Promise<void> =>
       this.performActionWithoutResourceResponse('recreate-webhook'),
 
+    /**
+     * Gets the primary webhook for this Assigned Content Type.
+     */
     webhook: (): Promise<Webhook> =>
       this.fetchLinkedResource('webhook', {}, Webhook),
 
+    /**
+     * Gets the active content webhook for this Assigned Content Type.
+     */
     activeContentWebhook: (): Promise<Webhook> =>
       this.fetchLinkedResource('active-content-webhook', {}, Webhook),
 
+    /**
+     * Gets the archived content webhook for this Assigned Content Type.
+     */
     archivedContentWebhook: (): Promise<Webhook> =>
       this.fetchLinkedResource('archived-content-webhook', {}, Webhook),
   };

--- a/src/lib/model/AssignedContentType.ts
+++ b/src/lib/model/AssignedContentType.ts
@@ -1,5 +1,6 @@
 import { HalResource } from '../hal/models/HalResource';
 import { Page } from './Page';
+import { Webhook } from './Webhook';
 
 /**
  * Class representing an Assigned Content Type for an Algolia Search Index.
@@ -33,6 +34,15 @@ export class AssignedContentType extends HalResource {
 
     recreateWebhook: (): Promise<void> =>
       this.performActionWithoutResourceResponse('recreate-webhook'),
+
+    webhook: (): Promise<Webhook> =>
+      this.fetchLinkedResource('webhook', {}, Webhook),
+
+    activeContentWebhook: (): Promise<Webhook> =>
+      this.fetchLinkedResource('active-content-webhook', {}, Webhook),
+
+    archivedContentWebhook: (): Promise<Webhook> =>
+      this.fetchLinkedResource('archived-content-webhook', {}, Webhook),
   };
 }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
There is no way to get the webhooks attached to assigned content types in search indexes.

## What is the new behaviour?
The user can now request the webhook, activeContentWebhook and archivedContentWebhook from an assigned content type. This is useful for discovering and updating webhooks used by search indexes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is used by the search indexes PR over in dc-cli.

