### PR TITLE
feat: add method to get localizations for ContentItem

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -2561,6 +2561,12 @@ export class DynamicContentFixtures {
       );
 
     mocks
+      .resource(LOCALIZATION_JOB, 'noself')
+      .nestedCollection('findByRootContentItem', {}, 'localization-jobs', [
+        LOCALIZATION_JOB,
+      ]);
+
+    mocks
       .resource(CONTENT_ITEM)
       .nestedCollection('localizations', {}, 'content-items', [CONTENT_ITEM]);
 

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -236,6 +236,11 @@ export const CONTENT_ITEM = {
         'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/versions{/version}',
       templated: true,
     },
+    localizations: {
+      href:
+        'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/localizations{?page,size,sort}',
+      templated: true,
+    },
     'content-item-versions': {
       href:
         'https://api.amplience.net/v2/content/content-items/a87fd535-fb25-44ee-b687-0db72bbab721/versions{?page,size,sort}',
@@ -2554,6 +2559,10 @@ export class DynamicContentFixtures {
         { locales: ['fr-FR'], version: 1 },
         LOCALIZATION_JOB
       );
+
+    mocks
+      .resource(CONTENT_ITEM)
+      .nestedCollection('localizations', {}, 'localizations', [CONTENT_ITEM]);
 
     // Content Types
     mocks

--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -2562,7 +2562,7 @@ export class DynamicContentFixtures {
 
     mocks
       .resource(CONTENT_ITEM)
-      .nestedCollection('localizations', {}, 'localizations', [CONTENT_ITEM]);
+      .nestedCollection('localizations', {}, 'content-items', [CONTENT_ITEM]);
 
     // Content Types
     mocks

--- a/src/lib/model/ContentItem.spec.ts
+++ b/src/lib/model/ContentItem.spec.ts
@@ -91,6 +91,18 @@ test('create localizations', async (t) => {
   t.is(localizationJob.status, 'IN_PROGRESS');
 });
 
+test('get localizations', async (t) => {
+  const client = new MockDynamicContent();
+
+  const contentItem = await client.contentItems.get(
+    'a87fd535-fb25-44ee-b687-0db72bbab721'
+  );
+
+  const itemLocalizations = await contentItem.related.localizations();
+
+  t.is(itemLocalizations.getItems()[0].label, 'Banner Ad Homepage');
+});
+
 test('content item with assignees', async (t) => {
   const client = new MockDynamicContent();
 
@@ -106,6 +118,7 @@ test('toJSON should copy resource attributes', async (t) => {
   const resource = await client.contentItems.get(
     'a87fd535-fb25-44ee-b687-0db72bbab721'
   );
+  console.log(resource);
   t.deepEqual(resource.toJSON(), {
     body: {
       _meta: {
@@ -121,7 +134,6 @@ test('toJSON should copy resource attributes', async (t) => {
     label: 'Banner Ad Homepage',
     lastModifiedBy: 'user',
     lastModifiedDate: '2018-06-26T12:54:16.216Z',
-    locale: 'en-GB',
     status: 'ACTIVE',
     version: 1,
   });

--- a/src/lib/model/ContentItem.spec.ts
+++ b/src/lib/model/ContentItem.spec.ts
@@ -118,7 +118,6 @@ test('toJSON should copy resource attributes', async (t) => {
   const resource = await client.contentItems.get(
     'a87fd535-fb25-44ee-b687-0db72bbab721'
   );
-  console.log(resource);
   t.deepEqual(resource.toJSON(), {
     body: {
       _meta: {

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -146,7 +146,7 @@ abstract class BaseContentItem extends HalResource {
      * Get localizations of the content item
      */
     localizations: (options?: Pageable): Promise<Page<ContentItem>> =>
-      this.fetchLinkedResource('localizations', options, LocalizationsPage),
+      this.fetchLinkedResource('localizations', options, ContentItemsPage),
 
     /**
      * Updates this Content Item with the changes in the mutation parameter.
@@ -232,15 +232,6 @@ export class ContentItem extends BaseContentItem {
 export class ContentItemsPage extends Page<ContentItem> {
   constructor(data?: any) {
     super('content-items', ContentItem, data);
-  }
-}
-
-/**
- * @hidden
- */
-export class LocalizationsPage extends Page<ContentItem> {
-  constructor(data?: any) {
-    super('localizations', ContentItem, data);
   }
 }
 

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -2,6 +2,7 @@ import { HalResource } from '../hal/models/HalResource';
 import { ContentRepository } from './ContentRepository';
 import { LocalizationJob } from './LocalizationJob';
 import { Page } from './Page';
+import { Pageable } from './Pageable';
 import { Status } from './Status';
 import { HierarchyMeta } from './HierarchyNode';
 import { FacetsResponse } from './Facets';
@@ -142,6 +143,12 @@ abstract class BaseContentItem extends HalResource {
       ),
 
     /**
+     * Get localizations of the content item
+     */
+    localizations: (options?: Pageable): Promise<Page<ContentItem>> =>
+      this.fetchLinkedResource('localizations', options, LocalizationsPage),
+
+    /**
      * Updates this Content Item with the changes in the mutation parameter.
      * You must provide the current version number in the mutation
      * to avoid overwriting other user's changes.
@@ -225,6 +232,15 @@ export class ContentItem extends BaseContentItem {
 export class ContentItemsPage extends Page<ContentItem> {
   constructor(data?: any) {
     super('content-items', ContentItem, data);
+  }
+}
+
+/**
+ * @hidden
+ */
+export class LocalizationsPage extends Page<ContentItem> {
+  constructor(data?: any) {
+    super('localizations', ContentItem, data);
   }
 }
 

--- a/src/lib/model/LocalizationJob.spec.ts
+++ b/src/lib/model/LocalizationJob.spec.ts
@@ -1,0 +1,23 @@
+import test from 'ava';
+import { MockDynamicContent } from '../DynamicContent.mocks';
+
+test('get fby Root Content Item', async (t) => {
+  const client = new MockDynamicContent();
+
+  const contentItem = await client.contentItems.get(
+    'a87fd535-fb25-44ee-b687-0db72bbab721'
+  );
+
+  const itemWithLocale = await contentItem.related.setLocale('en-GB');
+
+  const localizationJob = await itemWithLocale.related.localize(['fr-FR']);
+
+  t.is(localizationJob.status, 'IN_PROGRESS');
+
+  const localizationJobStatuses = await localizationJob.related.findByRootContentItem();
+
+  t.is(
+    localizationJobStatuses.getItems()[0].rootContentItem.id,
+    'a87fd535-fb25-44ee-b687-0db72bbab721'
+  );
+});

--- a/src/lib/model/LocalizationJob.spec.ts
+++ b/src/lib/model/LocalizationJob.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { MockDynamicContent } from '../DynamicContent.mocks';
 
-test('get fby Root Content Item', async (t) => {
+test('get by Root Content Item', async (t) => {
   const client = new MockDynamicContent();
 
   const contentItem = await client.contentItems.get(

--- a/src/lib/model/LocalizationJob.ts
+++ b/src/lib/model/LocalizationJob.ts
@@ -1,5 +1,8 @@
 import { HalResource } from '../hal/models/HalResource';
 import { LocalizationRoot } from './LocalizationRoot';
+import { Page } from './Page';
+import { Pageable } from './Pageable';
+import { Sortable } from './Sortable';
 
 /**
  * Class representing a LocalizationJob.
@@ -25,4 +28,27 @@ export class LocalizationJob extends HalResource {
    * Timestamp representing when the job was originally created (ISO 8601 format)
    */
   public createdDate?: string;
+
+  public readonly related = {
+    /**
+     * Retrieves the Localization Job Page
+     */
+    findByRootContentItem: (
+      options?: Pageable & Sortable
+    ): Promise<Page<LocalizationJob>> =>
+      this.fetchLinkedResource(
+        'findByRootContentItem',
+        { options },
+        LocalizationJobPage
+      ),
+  };
+}
+
+/**
+ * @hidden
+ */
+export class LocalizationJobPage extends Page<LocalizationJob> {
+  constructor(data?: any) {
+    super('localization-jobs', LocalizationJob, data);
+  }
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
Management SDK is missing a method to get localizations for ContentItem.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Added method to get localizations for ContentItem.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

