### PR TITLE
fix: pass pagination parameters to edition list-slots link

### DIFF
--- a/src/lib/hal/models/HalResource.ts
+++ b/src/lib/hal/models/HalResource.ts
@@ -225,6 +225,18 @@ export class HalResource {
         `The ${name} action is not available, ensure you have permission to perform this action.`
       );
     }
+
+    if (name === 'list-slots' && link.templated) {
+      // Work around an API bug where pagination params are not included for list-slots.
+      const toReplace = '{?includedSlots}';
+      const toReplaceWith = '{?includedSlots,page,size,sort}';
+      if (link.href.endsWith(toReplace)) {
+        link.href =
+          link.href.substr(0, link.href.length - toReplace.length) +
+          toReplaceWith;
+      }
+    }
+
     return Promise.resolve([link, this.client] as [HalLink, HalClient]);
   }
 }

--- a/src/lib/model/Edition.ts
+++ b/src/lib/model/Edition.ts
@@ -1,4 +1,4 @@
-import { HttpMethod } from '../..';
+import { HttpMethod, Pageable, Sortable } from '../..';
 import { HalResource } from '../hal/models/HalResource';
 import { EditionSlot, EditionSlotsPage } from './EditionSlot';
 import { EditionSlotRequest } from './EditionSlotRequest';
@@ -153,9 +153,10 @@ export class Edition extends HalResource {
     slots: {
       /**
        * Retrieves a list of slots associated with this Edition
+       * @param options Pagination options
        */
-      list: (): Promise<Page<EditionSlot>> =>
-        this.fetchLinkedResource('list-slots', {}, EditionSlotsPage),
+      list: (options?: Pageable & Sortable): Promise<Page<EditionSlot>> =>
+        this.fetchLinkedResource('list-slots', options, EditionSlotsPage),
 
       /**
        * Creates new edition slots from a list of content IDs


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Requesting an edition's slots does not pass any pagination parameters, so you always get back page 0 with size 20. This makes it impossible to list more than 20 slots.

## What is the new behaviour?
Listing slots now passes pagination parameters to the API.

- Params object is now passed when calling the `list-slots` HAL link.
- The `list-slots` HAL link from the API is automatically rewritten to include pagination parameters, so they are not ignored. This os a bug with the API.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

There's no planned fix for the HAL link bug for a while, hence the weird workaround.