### PR TITLE
fix: content type list supports status parameter

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -136,7 +136,7 @@ export const HUB = {
     },
     'content-types': {
       href:
-        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/content-types{?page,size,sort}',
+        'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/content-types{?page,size,sort,status}',
       templated: true,
     },
     'list-content-type-schemas': {
@@ -1904,6 +1904,58 @@ export const CONTENT_TYPE = {
 /**
  * @hidden
  */
+export const ARCHIVED_CONTENT_TYPE = {
+  id: '5be1d5134cedfd01c030c461',
+  contentTypeUri: 'http://deliver.bigcontent.io/schema/old-carousel.json',
+  status: 'ARCHIVED',
+  settings: {
+    label: 'Old Carousel',
+    icons: [
+      {
+        size: 256,
+        url: 'https://bigcontent.io/cms/icons/ca-types-grid-mixedmedia.png',
+      },
+    ],
+    visualizations: [
+      {
+        label: 'Desktop Website',
+        templatedUri: 'http://website',
+        default: true,
+      },
+      {
+        label: 'Mobile Website',
+        templatedUri: 'http://mobile.website',
+        default: false,
+      },
+    ],
+  },
+  _links: {
+    self: {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c461',
+    },
+    'content-type': {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c461',
+    },
+    'effective-content-type': {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c461/effective-content-type',
+    },
+    'content-type-schema': {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c461/schema',
+    },
+    unarchive: {
+      href:
+        'https://api.amplience.net/v2/content/content-types/5be1d5134cedfd01c030c461/unarchive',
+    },
+  },
+};
+
+/**
+ * @hidden
+ */
 const CONTENT_TYPE_UPDATED = {
   ...CONTENT_TYPE,
   settings: {
@@ -2459,6 +2511,12 @@ export class DynamicContentFixtures {
       .nestedCreateResource('create-workflow-state', {}, WORKFLOW_STATE)
       .nestedResource('content-types', {}, CONTENT_TYPE)
       .nestedCollection('content-types', {}, 'content-types', [CONTENT_TYPE])
+      .nestedCollection(
+        'content-types',
+        { status: Status.ARCHIVED },
+        'content-types',
+        [ARCHIVED_CONTENT_TYPE]
+      )
       .nestedCollection('workflow-states', {}, 'workflow-states', [
         WORKFLOW_STATE,
       ])
@@ -2818,6 +2876,7 @@ export class DynamicContentFixtures {
  * @hidden
  */
 import MockAdapter from 'axios-mock-adapter';
+import { Status } from './model/Status';
 
 /**
  * @hidden

--- a/src/lib/model/Hub.spec.ts
+++ b/src/lib/model/Hub.spec.ts
@@ -8,6 +8,7 @@ import { Extension } from './Extension';
 import { Snapshot } from './Snapshot';
 import { SnapshotType } from './SnapshotType';
 import { SnapshotCreator } from './SnapshotCreator';
+import { Status } from './Status';
 
 test('list hubs', async (t) => {
   const client = new MockDynamicContent();
@@ -154,6 +155,15 @@ test('list content types', async (t) => {
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
   const result = await hub.related.contentTypes.list();
   t.is(result.getItems()[0].settings.label, 'Carousel');
+});
+
+test('list archived content types', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const result = await hub.related.contentTypes.list({
+    status: Status.ARCHIVED,
+  });
+  t.is(result.getItems()[0].settings.label, 'Old Carousel');
 });
 
 test('get content type', async (t) => {

--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -21,6 +21,7 @@ import { WorkflowState, WorkflowStatesPage } from './WorkflowState';
 import { Extension, ExtensionsPage } from './Extension';
 import { Snapshot } from './Snapshot';
 import { SnapshotResultList } from './SnapshotResultList';
+import { StatusFilterable } from './StatusFilterable';
 
 /**
  * Class representing the [Hub](https://amplience.com/docs/api/dynamic-content/management/#resources-hubs) resource.
@@ -140,7 +141,9 @@ export class Hub extends HalResource {
        * Retrieves a list of Content Types associated with this Hub
        * @param options Pagination options
        */
-      list: (options?: Pageable & Sortable): Promise<Page<ContentType>> =>
+      list: (
+        options?: Pageable & Sortable & StatusFilterable
+      ): Promise<Page<ContentType>> =>
         this.fetchLinkedResource('content-types', options, ContentTypePage),
 
       /**

--- a/src/lib/model/StatusFilterable.ts
+++ b/src/lib/model/StatusFilterable.ts
@@ -1,0 +1,8 @@
+/**
+ * Parameters for filtering by status
+ */
+import { Status } from './Status';
+
+export interface StatusFilterable {
+  status?: Status;
+}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Listing content-types was missing `status` parameter.


## What is the new behaviour?
Introduced optional `status` parameter for content-type listing.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A

