### PR TITLE
feat: add shared token storage and lastPublished* fields

### DIFF
--- a/src/lib/DynamicContent.ts
+++ b/src/lib/DynamicContent.ts
@@ -20,6 +20,8 @@ import { HierarchyParents } from './model/HierarchyParents';
 import { HierarchyChildren } from './model/HierarchyChildren';
 import { WorkflowState } from './model/WorkflowState';
 import { Extension } from './model/Extension';
+import { AccessTokenStorage } from './oauth2/models/AccessTokenStorage';
+import { InMemoryStorage } from './oauth2/services/InMemoryStorage';
 
 /**
  * Configuration settings for Dynamic Content API client. You can optionally
@@ -272,7 +274,8 @@ export class DynamicContent {
   constructor(
     clientCredentials: Partial<OAuth2ClientCredentials>,
     dcConfig?: DynamicContentConfig,
-    httpClient?: AxiosRequestConfig | HttpClient
+    httpClient?: AxiosRequestConfig | HttpClient,
+    storage?: AccessTokenStorage
   ) {
     dcConfig = dcConfig || {};
     dcConfig.apiUrl = dcConfig.apiUrl || 'https://api.amplience.net/v2/content';
@@ -290,7 +293,8 @@ export class DynamicContent {
     const tokenClient = this.createTokenClient(
       dcConfig,
       clientCredentials as OAuth2ClientCredentials,
-      httpClientInstance
+      httpClientInstance,
+      storage || new InMemoryStorage()
     );
 
     this.client = this.createResourceClient(
@@ -303,14 +307,16 @@ export class DynamicContent {
   protected createTokenClient(
     dcConfig: DynamicContentConfig,
     clientCredentials: OAuth2ClientCredentials,
-    httpClient: HttpClient
+    httpClient: HttpClient,
+    storage: AccessTokenStorage
   ): AccessTokenProvider {
     return new OAuth2Client(
       clientCredentials,
       {
         authUrl: dcConfig.authUrl,
       },
-      httpClient
+      httpClient,
+      storage
     );
   }
 

--- a/src/lib/http/AxiosHttpClient.ts
+++ b/src/lib/http/AxiosHttpClient.ts
@@ -14,7 +14,9 @@ export class AxiosHttpClient implements HttpClient {
     this.client = axios.create(config);
   }
 
-  public request(config: HttpRequest): Promise<HttpResponse> {
+  public request<TResponseBody = Record<string, unknown>>(
+    config: HttpRequest
+  ): Promise<HttpResponse<TResponseBody>> {
     return this.client
       .request({
         data: config.data,

--- a/src/lib/http/HttpClient.ts
+++ b/src/lib/http/HttpClient.ts
@@ -5,5 +5,7 @@ import { HttpResponse } from './HttpResponse';
  * @hidden
  */
 export interface HttpClient {
-  request(config: HttpRequest): Promise<HttpResponse>;
+  request<TResponseBody = Record<string, unknown>>(
+    config: HttpRequest
+  ): Promise<HttpResponse<TResponseBody>>;
 }

--- a/src/lib/http/HttpResponse.ts
+++ b/src/lib/http/HttpResponse.ts
@@ -1,7 +1,7 @@
 /**
  * @hidden
  */
-export interface HttpResponse {
+export interface HttpResponse<TResponseBody = Record<string, unknown>> {
   status: number;
-  data: string | Record<string, unknown>;
+  data: string | TResponseBody;
 }

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -78,6 +78,16 @@ abstract class BaseContentItem extends HalResource {
   public lastModifiedDate: string;
 
   /**
+   * Last published version of content item
+   */
+  public lastPublishedVersion: number;
+
+  /**
+   * Timestamp representing when the content item was last published in ISO 8601 format
+   */
+  public lastPublishedDate: string;
+
+  /**
    * List of user Id' who are assigned to the content item
    */
   public assignees: string[];

--- a/src/lib/oauth2/models/AccessToken.ts
+++ b/src/lib/oauth2/models/AccessToken.ts
@@ -16,4 +16,10 @@ export interface AccessToken {
    * Period (in seconds) for how long the access token will remain valid
    */
   expires_in: number;
+
+  /**
+   * Custom field added on the client to remember the exact time when the
+   * token is expired
+   */
+  expires_at_locked_in?: number;
 }

--- a/src/lib/oauth2/services/OAuth2Client.spec.ts
+++ b/src/lib/oauth2/services/OAuth2Client.spec.ts
@@ -7,6 +7,7 @@ import { OAuth2Client } from './OAuth2Client';
  */
 // tslint:disable-next-line
 import MockAdapter from 'axios-mock-adapter';
+import { InMemoryStorage } from './InMemoryStorage';
 
 test('get token should request a token on the first invocation', async (t) => {
   const httpClient = new AxiosHttpClient({});
@@ -16,7 +17,8 @@ test('get token should request a token on the first invocation', async (t) => {
       client_secret: 'client_secret',
     },
     {},
-    httpClient
+    httpClient,
+    new InMemoryStorage()
   );
 
   const mock = new MockAdapter(httpClient.client);
@@ -42,7 +44,8 @@ test('get token should cache tokens', async (t) => {
       client_secret: 'client_secret',
     },
     {},
-    httpClient
+    httpClient,
+    new InMemoryStorage()
   );
 
   const mock = new MockAdapter(httpClient.client);
@@ -76,7 +79,7 @@ test('get token should cache tokens', async (t) => {
   t.is(token2.access_token, 'token');
 });
 
-test('cached tokens should expire', async (t) => {
+test.only('cached tokens should expire', async (t) => {
   const httpClient = new AxiosHttpClient({});
   const client = new OAuth2Client(
     {
@@ -84,7 +87,8 @@ test('cached tokens should expire', async (t) => {
       client_secret: 'client_secret',
     },
     {},
-    httpClient
+    httpClient,
+    new InMemoryStorage()
   );
 
   const mock = new MockAdapter(httpClient.client);
@@ -112,6 +116,7 @@ test('cached tokens should expire', async (t) => {
       refresh_token: 'refresh',
     });
 
+  debugger;
   const token2 = await client.getToken();
 
   t.is(token1.access_token, 'token');
@@ -126,7 +131,8 @@ test('only one token refresh should be in flight at once', async (t) => {
       client_secret: 'client_secret',
     },
     {},
-    httpClient
+    httpClient,
+    new InMemoryStorage()
   );
 
   const mock = new MockAdapter(httpClient.client, { delayResponse: 2000 });

--- a/src/lib/oauth2/services/OAuth2Client.ts
+++ b/src/lib/oauth2/services/OAuth2Client.ts
@@ -4,6 +4,7 @@ import { combineURLs } from '../../utils/URL';
 import { AccessToken } from '../models/AccessToken';
 import { AccessTokenProvider } from '../models/AccessTokenProvider';
 import { OAuth2ClientCredentials } from '../models/OAuth2ClientCredentials';
+import { AccessTokenStorage } from '../models/AccessTokenStorage';
 
 /**
  * @hidden
@@ -12,19 +13,20 @@ export class OAuth2Client implements AccessTokenProvider {
   public httpClient: HttpClient;
 
   private clientCredentials: OAuth2ClientCredentials;
-  private token: AccessToken;
-  private tokenExpires: number;
   private inFlight: Promise<AccessToken>;
   private authUrl: string;
+  private storage: AccessTokenStorage;
 
   constructor(
     clientCredentials: OAuth2ClientCredentials,
     { authUrl = 'https://auth.amplience.net' },
-    httpClient: HttpClient
+    httpClient: HttpClient,
+    storage: AccessTokenStorage
   ) {
     this.authUrl = authUrl;
     this.clientCredentials = clientCredentials;
     this.httpClient = httpClient;
+    this.storage = storage;
   }
 
   /**
@@ -39,8 +41,10 @@ export class OAuth2Client implements AccessTokenProvider {
       return this.inFlight;
     }
 
-    if (this.token != null && this.tokenExpires > Date.now()) {
-      return this.token;
+    const token = await this.storage.getToken(this.clientCredentials.client_id);
+
+    if (token != null && token.expires_at_locked_in > Date.now()) {
+      return token;
     }
 
     const payload =
@@ -50,7 +54,7 @@ export class OAuth2Client implements AccessTokenProvider {
       '&client_secret=' +
       encodeURIComponent(this.clientCredentials.client_secret);
 
-    const request = this.httpClient.request({
+    const request = this.httpClient.request<AccessToken>({
       data: payload,
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -60,17 +64,21 @@ export class OAuth2Client implements AccessTokenProvider {
     });
 
     this.inFlight = request.then(
-      (response): AccessToken => {
+      async (response): Promise<AccessToken> => {
         if (typeof response.data !== 'object') {
           throw new Error(
             'Unexpected response format from /oauth/token endpoint'
           );
         }
 
-        this.token = response.data as any;
-        this.tokenExpires = Date.now() + this.token.expires_in * 1000;
+        response.data.expires_at_locked_in =
+          Date.now() + response.data.expires_in * 1000;
+        await this.storage.saveToken(
+          this.clientCredentials.client_id,
+          response.data as any
+        );
         this.inFlight = null;
-        return this.token;
+        return (response.data as unknown) as AccessToken;
       }
     ) as Promise<AccessToken>;
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Each `DynamicContent` instance has one in memory stored access token. 

The `ContentItem` does not have `lastPublishedDate` and `lastPublishedVersion` presented in the SDK.

## What is the new behaviour?

- The token storage now can be provided as a separate class, which can help in a serverless environment, where servers go up and down in a matter of seconds, in that way we reduce the number of API calls to the Amplience Auth server. By default, the SDK will use `InMemoryStorage`.
- Also added `lastPublishedDate` and `lastPublishedVersion` to the SDK types, as they were missing.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

<!-- Any other information that is important to this PR -->

