### PR TITLE
feat: adds hub.related.contentItems.getByDeliveryKey() to lookup a co…

### DIFF
--- a/src/lib/DynamicContent.mocks.ts
+++ b/src/lib/DynamicContent.mocks.ts
@@ -176,6 +176,10 @@ export const HUB = {
     'linked-content-repositories': {
       href: 'https://api.amplience-qa.net/v2/content/hubs/5b32377e4cedfd01c45036d8/linked-content-repositories',
     },
+    'delivery-keys': {
+      href: 'https://api.amplience.net/v2/content/hubs/5b32377e4cedfd01c45036d8/delivery-keys?key={key}',
+      templated: true,
+    },
   },
 };
 
@@ -274,6 +278,20 @@ export const CONTENT_ITEM = {
  */
 export const CONTENT_ITEM_V2 = { ...CONTENT_ITEM };
 CONTENT_ITEM_V2.version++;
+
+/**
+ * @hidden
+ */
+export const CONTENT_ITEM_WITH_DELIVERY_KEY = {
+  ...CONTENT_ITEM,
+  body: {
+    _meta: {
+      name: 'main-banner',
+      schema: 'http://deliver.bigcontent.io/schema/nested/nested-type.json',
+      deliveryKey: 'a-delivery-key',
+    },
+  },
+};
 
 /**
  * @hidden
@@ -2486,6 +2504,11 @@ export class DynamicContentFixtures {
       `${hubMockResource.resource._links['self'].href}/content-repositories/search/findByFeaturesContaining?feature=slots`,
       'content-repositories',
       [CONTENT_REPOSITORY_SLOTS]
+    );
+
+    hubMockResource.mocks.resource(
+      CONTENT_ITEM_WITH_DELIVERY_KEY,
+      `${hubMockResource.resource._links['self'].href}/delivery-keys/content-item?key=a-delivery-key`
     );
 
     // Content items

--- a/src/lib/model/Hub.spec.ts
+++ b/src/lib/model/Hub.spec.ts
@@ -115,6 +115,15 @@ test('facet the content items ', async (t) => {
   );
 });
 
+test('get content item by its deliveryKey', async (t) => {
+  const client = new MockDynamicContent();
+  const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');
+  const result = await hub.related.contentItems.getByDeliveryKey(
+    'a-delivery-key'
+  );
+  t.is(result.body._meta.deliveryKey, 'a-delivery-key');
+});
+
 test('list events', async (t) => {
   const client = new MockDynamicContent();
   const hub = await client.hubs.get('5b32377e4cedfd01c45036d8');

--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -1,5 +1,9 @@
 import { HalResource } from '../hal/models/HalResource';
-import { ContentItemsFacets, FacetedContentItem } from './ContentItem';
+import {
+  ContentItem,
+  ContentItemsFacets,
+  FacetedContentItem,
+} from './ContentItem';
 import {
   ContentRepositoriesPage,
   ContentRepository,
@@ -191,6 +195,12 @@ export class Hub extends HalResource {
           options,
           facetQuery,
           ContentItemsFacets
+        ),
+
+      getByDeliveryKey: (key: string): Promise<ContentItem> =>
+        this.client.fetchResource(
+          `hubs/${this.id}/delivery-keys/content-item?key=${key}`,
+          ContentItem
         ),
     },
 


### PR DESCRIPTION
…ntent-item by its delivery key

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [ ] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
-


## What is the new behaviour?
- able to fetch a content item by it's delivery key
- 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

