### PR TITLE
fix: fixing module version in tsconfig for backward compatibility iss…

### DIFF
--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,11 +1,9 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES2020",
     "outDir": "build/module",
-    "module": "esnext"
+    "module": "ES2020"
   },
-  "exclude": [
-    "node_modules/**"
-  ]
+  "exclude": ["node_modules/**"]
 }


### PR DESCRIPTION
…ue with typescript upgrade

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
The latest Typescript update was causing the "module" build to no pass through data to classes as it did before.  Classes that extended the `HalResource` and passed data through the constructor are being overwritten with `undefined`.  This is due to a change in the way Typescript initialised classes.  

Previously the proper for the class would be setup (as undefined) and then the `HalResource` constructor was called and any data passed was parsed (and assigned to the appropriate undefined props).

The changes to Typescript reverses this order so the `HalResource` constructor is run first and then the props setup.  Resulting in the props being set back to `undefined`.

## What is the new behaviour?

We have fixed the tsconfig module to `ES2020` so that Typescript builds using the original implementation giving the build backwards compatibility.  This is the supported version esnext was using for Typescript 3.8 - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#es2020-for-target-and-module

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

