### PR TITLE
feat: add force sync param

### DIFF
--- a/src/lib/model/Job.spec.ts
+++ b/src/lib/model/Job.spec.ts
@@ -19,6 +19,7 @@ test('create job', async (t) => {
       rootContentItemIds: ['a87fd535-fb25-44ee-b687-0db72bbab721'],
     },
     ignoreSchemaValidation: false,
+    forceSync: false,
   });
   const createdJob = await hub.related.jobs.createDeepSyncJob(request);
 

--- a/src/lib/model/Job.ts
+++ b/src/lib/model/Job.ts
@@ -33,6 +33,7 @@ export type JobError = {
 interface iCreateDeepSyncJobRequest {
   label: string;
   ignoreSchemaValidation: boolean;
+  forceSync: boolean;
   destinationHubId: string;
   input: {
     rootContentItemIds: string[];
@@ -48,6 +49,10 @@ export class CreateDeepSyncJobRequest implements iCreateDeepSyncJobRequest {
    * Should schema validation be ignored if allowed at the hub level?
    */
   public ignoreSchemaValidation: boolean;
+  /**
+   * Should unmodified content items be force synced to the destination hub?
+   */
+  public forceSync: boolean;
   /**
    * Destination hub ID
    */

--- a/src/lib/model/Job.ts
+++ b/src/lib/model/Job.ts
@@ -33,7 +33,7 @@ export type JobError = {
 interface iCreateDeepSyncJobRequest {
   label: string;
   ignoreSchemaValidation: boolean;
-  forceSync: boolean;
+  forceSync?: boolean;
   destinationHubId: string;
   input: {
     rootContentItemIds: string[];
@@ -52,7 +52,7 @@ export class CreateDeepSyncJobRequest implements iCreateDeepSyncJobRequest {
   /**
    * Should unmodified content items be force synced to the destination hub?
    */
-  public forceSync: boolean;
+  public forceSync?: boolean;
   /**
    * Destination hub ID
    */


### PR DESCRIPTION
Added the new forceSync param for create deep sync job

TAR-1387

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
Force sync is not supported


## What is the new behaviour?
`forceSync` param added for `hub.createDeepSyncJob()`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

<!-- Any other information that is important to this PR -->

