### PR TITLE
feat: support for scheduling content/hierarchies using edition-content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,3 +120,6 @@ export {
 export { LinkedContentRepository } from './lib/model/LinkedContentRepository';
 export { PublishingJob } from './lib/model/PublishingJob';
 export { PublishingJobLocation } from './lib/model/PublishingJobLocation';
+export { EditionContent } from './lib/model/EditionContent';
+export { EditionContents } from './lib/model/EditionContents';
+export { HierarchySnapshotRequest } from './lib/model/HierarchySnapshotRequest';

--- a/src/lib/model/Edition.ts
+++ b/src/lib/model/Edition.ts
@@ -1,5 +1,7 @@
 import { HttpMethod, Pageable, Sortable } from '../..';
 import { HalResource } from '../hal/models/HalResource';
+import { EditionContent, EditionContentPage } from './EditionContent';
+import { EditionContents } from './EditionContents';
 import { EditionSlot, EditionSlotsPage } from './EditionSlot';
 import { EditionSlotRequest } from './EditionSlotRequest';
 import { Event } from './Event';
@@ -167,6 +169,31 @@ export class Edition extends HalResource {
           {},
           slots,
           EditionSlotsPage
+        ),
+    },
+
+    editionContents: {
+      /**
+       * Retrieves a list of edition-content associated with this Edition
+       * @param options Pagination options
+       */
+      list: (options?: Pageable & Sortable): Promise<Page<EditionContent>> =>
+        this.fetchLinkedResource(
+          'edition-contents',
+          options,
+          EditionContentPage
+        ),
+
+      /**
+       * Creates a new edition-content associated with this Edition.
+       * Used to schedule content to be published on a specific date.
+       */
+      create: () =>
+        this.createLinkedResource(
+          'create-edition-content',
+          {},
+          new EditionContents({}),
+          EditionContents
         ),
     },
 

--- a/src/lib/model/EditionContent.ts
+++ b/src/lib/model/EditionContent.ts
@@ -1,0 +1,58 @@
+import { HalResource } from '../hal/models/HalResource';
+import { Page } from './Page';
+import { Snapshot } from './Snapshot';
+
+/**
+ * EditionContent represents the content of an Edition
+ */
+export class EditionContent extends HalResource {
+  /**
+   * Create from a snapshot - this is useful for creating a new edition from an existing snapshot
+   * @param snapshot
+   * @returns
+   */
+  static fromSnapshot(snapshot: Snapshot): EditionContent {
+    // For backwards compatibility reasons, some snapshots may have a single rootContentItem property instead of an array of rootContentItems.
+    const rootContentItem =
+      snapshot.rootContentItems[0] || snapshot.rootContentItem;
+    return new EditionContent({
+      body: {
+        contents: [
+          {
+            _meta: {
+              schema:
+                'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
+              rootContentItemIds: [rootContentItem.id],
+              locked: false,
+            },
+            id: snapshot.id,
+            contentType: rootContentItem.contentTypeUri,
+          },
+        ],
+      },
+    });
+  }
+  /**
+   * The body of the edition content - this is the same format as the body of a snapshot, but with an additional "locked" property in the _meta object to indicate whether the content item is locked for editing or not
+   */
+  public body?: {
+    contents: {
+      _meta: {
+        schema: string;
+        rootContentItemIds: string[];
+        locked: boolean;
+      };
+      id: string;
+      contentType: string;
+    }[];
+  };
+}
+
+/**
+ * @hidden
+ */
+export class EditionContentPage extends Page<EditionContent> {
+  constructor(data?: any) {
+    super('edition-content', EditionContent, data);
+  }
+}

--- a/src/lib/model/EditionContent.ts
+++ b/src/lib/model/EditionContent.ts
@@ -15,6 +15,14 @@ export class EditionContent extends HalResource {
     // For backwards compatibility reasons, some snapshots may have a single rootContentItem property instead of an array of rootContentItems.
     const rootContentItem =
       snapshot.rootContentItems[0] || snapshot.rootContentItem;
+    if (!rootContentItem) {
+      throw new Error(
+        'Snapshot must have at least one root content item to create an EditionContent'
+      );
+    }
+    const ids = snapshot.rootContentItems.map((item) => item.id) || [
+      snapshot.rootContentItem.id,
+    ];
     return new EditionContent({
       body: {
         contents: [
@@ -22,7 +30,7 @@ export class EditionContent extends HalResource {
             _meta: {
               schema:
                 'http://bigcontent.io/cms/schema/v1/core#/definitions/content-link',
-              rootContentItemIds: [rootContentItem.id],
+              rootContentItemIds: ids,
               locked: false,
             },
             id: snapshot.id,

--- a/src/lib/model/EditionContents.ts
+++ b/src/lib/model/EditionContents.ts
@@ -1,0 +1,30 @@
+import { HalResource } from '../hal/models/HalResource';
+import { Edition } from './Edition';
+import { EditionContent } from './EditionContent';
+
+/**
+ * EditionsContents represents the content of an Edition, and provides methods for updating the content and retrieving the associated Edition
+ */
+export class EditionContents extends HalResource {
+  public id?: string;
+  public content?: EditionContent | null;
+  public readonly related = {
+    /**
+     * Update content of this EditionContents
+     */
+    updateContent: (mutation: EditionContent): Promise<EditionContent> =>
+      this.updateLinkedResource('content', {}, mutation, EditionContent),
+
+    /**
+     * Updates this EditionContents
+     */
+    update: (mutation: EditionContents): Promise<EditionContents> =>
+      this.updateResource(mutation, EditionContents),
+
+    /**
+     * Retrieves the Edition associated with this EditionContent
+     */
+    edition: (): Promise<Edition> =>
+      this.fetchLinkedResource('edition', {}, Edition),
+  };
+}

--- a/src/lib/model/HierarchySnapshotRequest.ts
+++ b/src/lib/model/HierarchySnapshotRequest.ts
@@ -1,0 +1,24 @@
+import { HalResource } from '../hal/models/HalResource';
+import { SnapshotType } from './SnapshotType';
+
+/**
+ * Class representing the request body for creating a snapshot of a content hierarchy.
+ */
+export class HierarchySnapshotRequest extends HalResource {
+  /**
+   * hierarchyNodeIds is the list of content item ids that will be snapshotted.
+   */
+  public hierarchyNodeIds: string[];
+  /**
+   * Include all descendant content items of the specified hierarchyNodeIds in the snapshot when set to true. Otherwise, only the specified content items will be included in the snapshot.
+   */
+  public getDescendants: boolean;
+  /**
+   * Snapshot type to create. See SnapshotType for more details on the different snapshot types available.
+   */
+  public type: SnapshotType;
+  /**
+   * Comment to be associated with the snapshot.
+   */
+  public comment: string;
+}

--- a/src/lib/model/Hub.ts
+++ b/src/lib/model/Hub.ts
@@ -39,6 +39,7 @@ import {
   LinkedContentRepository,
 } from './LinkedContentRepository';
 import { HttpMethod } from '../http/HttpRequest';
+import { HierarchySnapshotRequest } from './HierarchySnapshotRequest';
 
 /**
  * Class representing the [Hub](https://amplience.com/docs/api/dynamic-content/management/#resources-hubs) resource.
@@ -486,6 +487,21 @@ export class Hub extends HalResource {
        */
       get: (jobId: string): Promise<Job> =>
         this.fetchLinkedResource('job', { jobId }, Job),
+    },
+
+    hierarchies: {
+      /**
+       * Creates a snapshot of a content item hierarchy. The snapshot will include the content item specified and all of its descendant content items.
+       * @param request
+       * @returns
+       */
+      createSnapshot: (request: HierarchySnapshotRequest): Promise<Snapshot> =>
+        this.performActionThatReturnsResource(
+          'snapshot-hierarchy',
+          {},
+          request,
+          Snapshot
+        ),
     },
   };
 }

--- a/src/lib/model/Snapshot.ts
+++ b/src/lib/model/Snapshot.ts
@@ -5,6 +5,24 @@ import { SnapshotCreator } from './SnapshotCreator';
 import { SnapshotType } from './SnapshotType';
 
 /**
+ * Root content item information included in a Snapshot response
+ */
+type RootContentItem = {
+  /**
+   * Label of the content item
+   */
+  label: string;
+  /**
+   * Content type URI of the content item
+   */
+  contentTypeUri: string;
+  /**
+   * Id of the content item
+   */
+  id: string;
+};
+
+/**
  * Class representing the [Snapshot](https://amplience.com/docs/api/dynamic-content/management/#tag/Snapshots) resource.
  * A Snapshot is an immutable representation of a content item with all of its descendants (including their versions) at a given point in time.
  */
@@ -38,6 +56,16 @@ export class Snapshot extends HalResource {
    * Snapshot type
    */
   public type?: SnapshotType;
+
+  /**
+   * Root content item
+   */
+  public rootContentItem?: RootContentItem;
+
+  /**
+   * Root content items
+   */
+  public rootContentItems?: RootContentItem[];
 
   /**
    * Resources and actions related to a Snapshot


### PR DESCRIPTION
…ntent-item by its delivery key

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [ ] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
No edition content scheduling support


## What is the new behaviour?
Able to add content/hierarchy nodes to an edition

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

