### PR TITLE
feat: TAR-1865 Added replicateFolderStructure to localize method

### DIFF
--- a/src/lib/model/ContentItem.spec.ts
+++ b/src/lib/model/ContentItem.spec.ts
@@ -127,7 +127,10 @@ test('create localizations', async (t) => {
 
   const itemWithLocale = await contentItem.related.setLocale('en-GB');
 
-  const localizationJob = await itemWithLocale.related.localize(['fr-FR']);
+  const localizationJob = await itemWithLocale.related.localize(
+    ['fr-FR'],
+    true
+  );
 
   t.is(localizationJob.status, 'IN_PROGRESS');
 });

--- a/src/lib/model/ContentItem.ts
+++ b/src/lib/model/ContentItem.ts
@@ -145,12 +145,20 @@ abstract class BaseContentItem extends HalResource {
     /**
      * Create localizations of the content item
      * @param locales Array of locales to create
+     * @param replicateFolderStructure Should the localised items be created in the same folder as the original items or at the root of the repository. Default is false (create at root)
      */
-    localize: (localesList: string[]): Promise<any> =>
+    localize: (
+      localesList: string[],
+      replicateFolderStructure = false
+    ): Promise<any> =>
       this.performActionThatReturnsResource(
         'create-localizations',
         {},
-        { locales: localesList, version: this.version },
+        {
+          locales: localesList,
+          version: this.version,
+          replicateFolderStructure,
+        },
         LocalizationJob
       ),
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Docs (`npm run doc`) have been reviewed and added / updated if needed (for bug fixes / features)
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behaviour?
repllcateFolderStructure option is not available when localising


## What is the new behaviour?
exposing repllcateFolderStructure argument

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR -->

